### PR TITLE
Pruning clarifications

### DIFF
--- a/draft-ietf-ice-rfc5245bis.xml
+++ b/draft-ietf-ice-rfc5245bis.xml
@@ -3220,8 +3220,8 @@ restart
 
 <t>
 Unless an agent is able to produce a selected pair for all components
-associated with a media strem, the agent MUST NOT continue
-sedning media for any component associated with that media stream.
+associated with a media stream, the agent MUST NOT continue
+sending media for any component associated with that media stream.
 </t>
 
 
@@ -3267,7 +3267,7 @@ one candidate pair to another.  </t>
 <section anchor="sec-recv-media" title="Receiving Media">
 
 <t>
-Eventhough, ICE agents are only allowed to send media using valid
+Even though ICE agents are only allowed to send media using valid
 candidiate pairs (and, once a candidiate pair has been selected, only
 on the selected pair) ICE implementations SHOULD by default be prepared
 to receive media on any of the candidiates provided in the most recent

--- a/draft-ietf-ice-rfc5245bis.xml
+++ b/draft-ietf-ice-rfc5245bis.xml
@@ -723,10 +723,11 @@ relayed candidate is resident on the TURN server, and the TURN server
 relays packets back towards the agent.
 </t>
 
-<t hangText="Base:"> The base of a server reflexive candidate is the
-host candidate from which it was derived. A host candidate is also
-said to have a base, equal to that candidate itself. Similarly, the
-base of a relayed candidate is that candidate itself.
+<t hangText="Base:"> The transport address that an agent sends from
+for a particular candidate. For host-, server reflexive- and peer reflexive
+candidates the base is the same as the host candidate. For relayed
+candidates the base is the same as the relayed candidate (i.e., the
+transport address used by the TURN server to send from).
 </t>
 
 <t hangText="Foundation:"> An arbitrary string that is the same for
@@ -896,8 +897,7 @@ candidates, server reflexive candidates, peer reflexive candidates,
 and relayed candidates.  The server reflexive candidates are gathered
 using STUN or TURN, and relayed candidates are obtained through TURN.
 Peer reflexive candidates are obtained in later phases of ICE, as a
-consequence of connectivity checks.  The base of a candidate is the
-candidate that an agent must send from when using that candidate.
+consequence of connectivity checks.
 </t>
 
 <t>
@@ -1609,9 +1609,13 @@ of this specification.
 There is one check list per in-use media stream resulting from the
 candidate exchange.  To form the check list for a media stream, the
 agent forms candidate pairs, computes a candidate pair priority,
-orders the pairs by priority, prunes them, and sets their
-states. These steps are described in this section.
+orders the pairs by priority, prunes them, removes lower-priority
+candidates and sets their states. These steps are described in this section.
+If a check list is updated (e.g, due to detection of peer reflexive
+candidates), the agent will re-perform the steps for the updated
+check list.
 </t>
+
 
 <section title="Forming Candidate Pairs">
 
@@ -1619,9 +1623,7 @@ states. These steps are described in this section.
 First, the agent takes each of its candidates for a media stream
 (called LOCAL CANDIDATES) and pairs them with the candidates it
 received from its peer (called REMOTE CANDIDATES) for that media
-stream. In order to prevent the attacks described in <xref
-target="sec-ice-hammer"/>, agents MAY limit the number of candidates
-they'll accept in an candidate exchange process. A local candidate is
+stream. A local candidate is
 paired with a remote candidate if and only if the two candidates have
 the same component ID and have the same IP address version. It is
 possible that some of the local candidates won't get paired with
@@ -1653,9 +1655,9 @@ paired with other than link-local addresses. </t>
 
 <t>
 The candidate pairs whose local and remote candidates are both the
-default candidates for a particular component is called,
-unsurprisingly, the default candidate pair for that component. This is
-the pair that would be used to transmit media if both agents had not
+default candidates for a particular component is called the
+default candidate pair for that component. This is the pair that
+would be used to transmit media if both agents had not
 been ICE aware.
 </t>
 
@@ -1747,19 +1749,23 @@ identical priority, the ordering amongst them is arbitrary.
 This sorted list of candidate pairs is used to determine a sequence of
 connectivity checks that will be performed. Each check involves
 sending a request from a local candidate to a remote candidate. Since
-an agent cannot send requests directly from a reflexive candidate, but
-only from its base, the agent next goes through the sorted list of
-candidate pairs. For each pair where the local candidate is server
-reflexive, the server reflexive candidate MUST be replaced by its
-base. Once this has been done, the agent MUST prune the list. This is
-done by removing a pair if its local and remote candidates are
-identical to the local and remote candidates of a pair higher up on
+an agent cannot send requests directly from a reflexive candidate
+(server reflexive or peer reflexive), but only from its base, the
+agent next goes through the sorted list of candidate pairs. For each
+pair where the local candidate is reflexive, the candidate MUST be
+replaced by its base. Once this has been done, the agent MUST prune
+the list. This is done by removing a pair if its local and remote candidates
+are identical to the local and remote candidates of a pair higher up on
 the priority list. The result is a sequence of ordered candidate
 pairs, called the check list for that media stream.
 </t>
 
+</section>
+
+<section title="Removing lower-priority Pairs">
+
 <t>
-In addition, in order to limit the attacks described in <xref
+In order to limit the attacks described in <xref
 target="sec-ice-hammer"/>, an agent MUST limit the total number of
 connectivity checks the agent performs across all check lists to a
 specific value, and this value MUST be configurable. A default of 100
@@ -2303,8 +2309,8 @@ as checks are performed, resulting in valid candidate pairs.
 <t>
 It will be very common that the pair will not be on any check list.
 Recall that the check list has pairs whose local candidates are never
-server reflexive; those pairs had their local candidates converted to
-the base of the server reflexive candidates, and then pruned if they
+reflexive; those pairs had their local candidates converted to
+the base of the reflexive candidates, and then pruned if they
 were redundant. When the response to the STUN check arrives, the
 mapped address will be reflexive if there is a NAT between the two. In
 that case, the valid pair will have a local candidate that doesn't
@@ -3171,19 +3177,19 @@ Procedures for sending media differ for full and lite implementations.
 <section title="Procedures for Full Implementations">
 
 <t>
-Agents always send media using a candidate pair, called the selected
-candidate pair. An agent will send media to the remote candidate in
+Agents always send media using a candidate pair, using candidate pairs
+in the Valid list. An agent will send media to the remote candidate in
 the selected pair (setting the destination address and port of the
 packet equal to that remote candidate), and will send it from the
-local candidate of the selected pair. When the local candidate is
-server or peer reflexive, media is originated from the base. Media
-sent from a relayed candidate is sent from the base through that TURN
-server, using procedures defined in <xref target="RFC5766"/>.
+base associated with the selected pair. In case of a relayed
+candidate, media is sent from the agent and forwareded through
+the base (located in the TURN server), using the procedures defined
+in <xref target="RFC5766"/>.
 </t>
 
 <t>
 If the local candidate is a relayed candidate, it is RECOMMENDED that
-an agent create a channel on the TURN server towards the remote
+an agent creates a channel on the TURN server towards the remote
 candidate.  This is done using the procedures for channel creation as
 defined in Section 11 of <xref target="RFC5766"/>.
 </t>

--- a/draft-ietf-ice-rfc5245bis.xml
+++ b/draft-ietf-ice-rfc5245bis.xml
@@ -816,6 +816,9 @@ receiving media.
 <t hangText="Selected Pair, Selected Candidate:"> The candidate pair
 selected by ICE for sending and receiving media is called the selected
 pair, and each of its candidates is called the selected candidate.
+Before a candidiate pair has been selected, any valid candidiate pair
+can be used for sending and receiving media (only one candidiate pair
+at any given time).
 </t>
 
 <t hangText="Using Protocol, ICE Usage:"> The protocol that uses ICE
@@ -1903,7 +1906,7 @@ progress for this media stream.
 </t>
 
 <t hangText="Completed:"> In this state, ICE checks have produced
-nominated pairs for each component of the media stream.
+selected pairs for each component of the media stream.
 </t>
 
 <t hangText="Failed:"> In this state, the ICE checks have not
@@ -3178,10 +3181,12 @@ Procedures for sending media differ for full and lite implementations.
 
 <t>
 Agents always send media using a candidate pair, using candidate pairs
-in the Valid list. An agent will send media to the remote candidate in
-the selected pair (setting the destination address and port of the
-packet equal to that remote candidate), and will send it from the
-base associated with the selected pair. In case of a relayed
+in the Valid list. Once a candidiate pair has been selected only that
+candidiate pair (referred to as selected pair) is used for
+sending media. An agent will send media to the remote candidate (i.e.,
+setting the destination address and port of the packet equal to that
+remote candidate), and will send it from the base associated with the
+candidiate pair used for sending media. In case of a relayed
 candidate, media is sent from the agent and forwareded through
 the base (located in the TURN server), using the procedures defined
 in <xref target="RFC5766"/>.
@@ -3210,19 +3215,13 @@ there was a previous selected pair for that component due to an ICE
 restart
 </t>
 
-<t>
-equal to the highest-priority nominated pair for that component in the
-valid list if the state of the check list is Completed
-</t>
 </list>
 </t>
 
 <t>
-If the selected pair for at least one component of a media stream is
-empty, an agent MUST NOT send media for any component of that media
-stream. If the selected pair for each component of a media stream has
-a value, an agent MAY send media for all components of that media
-stream.
+Unless an agent is able to produce a selected pair for all components
+associated with a media strem, the agent MUST NOT continue
+sedning media for any component associated with that media stream.
 </t>
 
 
@@ -3237,7 +3236,11 @@ that contains a candidate pair for each component of that media
 stream. Once that happens, the agent MAY begin sending media
 packets. To do that, it sends media to the remote candidate in the
 pair (setting the destination address and port of the packet equal to
-that remote candidate), and will send it from the local candidate.
+that remote candidate), and will send it from the base associated with the
+candidiate pair used for sending media. In case of a relayed
+candidate, media is sent from the agent and forwareded through
+the base (located in the TURN server), using the procedures defined
+in <xref target="RFC5766"/>.
 </t>
 
 </section>
@@ -3264,10 +3267,14 @@ one candidate pair to another.  </t>
 <section anchor="sec-recv-media" title="Receiving Media">
 
 <t>
-ICE implementations MUST be prepared to receive media on each
-component on any candidates provided for that component in the most
-recent candidate exchange (in the case of RTP, this would include
-both RTP and RTCP if candidates were provided for both).
+Eventhough, ICE agents are only allowed to send media using valid
+candidiate pairs (and, once a candidiate pair has been selected, only
+on the selected pair) ICE implementations SHOULD by default be prepared
+to receive media on any of the candidiates provided in the most recent
+candidiate exchange with the peer. Specific ICE usages MAY define rules
+that differe from this, e.g., by defining that media must not be sent
+until selected pairs have been procduced for each component associated
+with that media.
 </t>
 
 <t>It is


### PR DESCRIPTION
Prune clarification, and adding the text about removing lower-priority candidates into separate section. Also clarifying that check list procedures are re-done whenever a check list is updated.