### PR TITLE
Rewrite the "Ta fired" procedures in the form of sequential steps.

### DIFF
--- a/draft-ietf-ice-rfc5245bis.xml
+++ b/draft-ietf-ice-rfc5245bis.xml
@@ -2028,38 +2028,36 @@ is selected, and a check is performed for a candidate within that CHECK LIST.
 After the last CHECK LIST in the Running state in the CHECK LIST SET has been
 processed, the first CHECK LIST is selected again. Etc.
 </t>
-<t>NOTE: When timer Ta fires, and the agent processes a CHECK LIST, if no check
-is performed for a pair in the CHECK LIST (based on the rules below), the agent
-can immediately select the next CHECK LIST in the Running state, without waiting
-for timer Ta to expire again.
-</t>
 
 <t>
 Whenever Ta fires, the agent will perform a check for a candidate pair within
-the selected CHECK LIST as follows:
-<list style="symbols">
+the selected CHECK LIST by performing the following steps:
+<list style="numbers">
 <t>If the TRIGGERED CHECK QUEUE associated with the CHECK LIST contains
 one or more candidate pairs, the agent removes the top pair from the
-queue, performs a connectivity check on that pair and puts the candidate pair
-state to In-Progress; or
-</t>
-
-<t>If the TRIGGERED CHECK QUEUE associated with the CHECK LIST is empty, and
-if there are one or more candidate pairs in the Waiting state, the agent selects
-the highest-priority candidate pair (if there are multiple pairs with the same
-priority, the pair with the lowest component ID is selected) in the Waiting
-state, performs a connectivity check on that pair and puts the candidate pair
-par state to In-Progress; or
+queue, performs a connectivity check on that pair, puts the candidate pair
+state to In-Progress, and aborts these steps.
 </t>
 
 <t>If there is no candidate pair in the Waiting state, and if there are one or
-more pairs in the Frozen state, for each pair in the Frozen state the the agent
+more pairs in the Frozen state, for each pair in the Frozen state the agent
 checks the foundation associated with the pair. For a given foundation, if there
 is no pair (in any CHECK LIST in the CHECK LIST SET) in the Waiting or In-Progress state,
-the agent performs a connectivity check on the pair and puts the pair state to In-Prograss.
-If, for the same foundation, there are one or more pairs in the Waiting or In-Progress state,
-(in any CHECK LIST in the CHECK LIST SET) the agent does not perform a connectivity check
-on the pair.
+the agent puts the candidate pair state to Waiting.
+</t>
+
+<t>If there are one or more candidate pairs in the Waiting state, the agent selects
+the highest-priority candidate pair (if there are multiple pairs with the same
+priority, the pair with the lowest component ID is selected) in the Waiting
+state, performs a connectivity check on that pair, puts the candidate pair
+par state to In-Progress, and abort these steps.
+</t>
+
+<t>If this step is reached, no check could be performed for the selected CHECK
+LIST. So, without waiting for timer Ta to expire again, select the next CHECK
+LIST in the Running state and return to step #1. If this happens for every single
+CHECK LIST in the Running state, meaning there are no remaining candidate pairs
+to perform connectivity checks for, abort these steps.
 </t>
 
 </list></t>

--- a/draft-ietf-ice-rfc5245bis.xml
+++ b/draft-ietf-ice-rfc5245bis.xml
@@ -2036,7 +2036,7 @@ the selected CHECK LIST by performing the following steps:
 <t>If the TRIGGERED CHECK QUEUE associated with the CHECK LIST contains
 one or more candidate pairs, the agent removes the top pair from the
 queue, performs a connectivity check on that pair, puts the candidate pair
-state to In-Progress, and aborts these steps.
+state to In-Progress, and aborts the subsequent steps.
 </t>
 
 <t>If there is no candidate pair in the Waiting state, and if there are one or
@@ -2050,7 +2050,7 @@ the agent puts the candidate pair state to Waiting.
 the highest-priority candidate pair (if there are multiple pairs with the same
 priority, the pair with the lowest component ID is selected) in the Waiting
 state, performs a connectivity check on that pair, puts the candidate pair
-par state to In-Progress, and abort these steps.
+par state to In-Progress, and abort the subsequent steps.
 </t>
 
 <t>If this step is reached, no check could be performed for the selected CHECK

--- a/draft-ietf-ice-rfc5245bis.xml
+++ b/draft-ietf-ice-rfc5245bis.xml
@@ -2043,7 +2043,7 @@ state to In-Progress, and aborts the subsequent steps.
 more pairs in the Frozen state, for each pair in the Frozen state the agent
 checks the foundation associated with the pair. For a given foundation, if there
 is no pair (in any CHECK LIST in the CHECK LIST SET) in the Waiting or In-Progress state,
-the agent puts the candidate pair state to Waiting.
+the agent puts the candidate pair state to Waiting and continues with the next step.
 </t>
 
 <t>If there are one or more candidate pairs in the Waiting state, the agent selects


### PR DESCRIPTION
Alternate version of PR #33. Rather than structuring the Ta procedures
as:

* If `condition`, do `action`, or;
* If `condition`, do `action`, or;
* ...

This PR structures them more like pseudocode, with the ability for
multiple steps to be run in the same Ta cycle, reducing some text
duplication.