### PR TITLE
Clean up a few things

### DIFF
--- a/draft-ietf-ice-rfc5245bis.xml
+++ b/draft-ietf-ice-rfc5245bis.xml
@@ -1528,7 +1528,7 @@ a STUN request from the base of the local candiditate to the remote
 candidate following the procedures in <xref
 target="sec-connectivity_check"/>.  Then every time Ta fires, it
 chooses a candidate pair and sends a check.  After sending each check,
-the agent sets the candidate pair's state to In-Progress.
+the agent sets the candidate pair state to In-Progress.
 </t>
 
 <t>The agent chooses a candidate pair by first choosing a check list
@@ -1639,9 +1639,8 @@ when an ICE role conflict occurs <xref target="sec-role-conflict"/>.
 
 <section anchor="sec-client" title="STUN Client Procedures">
 <section anchor="sec-permissions" title="Creating Permissions for Relayed Candidates">
-<t>If the connectivity check is being sent using a relayed local
-candidate, the client MUST create a permission first if it has not
-already created one previously.  To create the permission, the agent
+<t>The agent MUST create a permission before sending a check from a relayed local
+candidate.  To create the permission, the agent
 follows the procedures defined in <xref target="RFC5766"/>.  The
 permission MUST be created towards the IP address of the remote
 candidate.  It is RECOMMENDED that the agent defer creation of a TURN
@@ -1693,87 +1692,79 @@ those same markings to its connectivity checks.
 <t>This section defines additional procedures for processing Binding responses
 specific to ICE connectivity checks.
 </t>
-<t>When a Binding response is received, it is correlated to the corresponding
-Binding request using the transaction ID <xref target="RFC5389"/>, which then
-associates the response with the candidate pair for which the Binding request
-was sent. After that, the response is processed according to the procedures for
-a role conflict, a failure, or a success, according to the procedures below.
+<t>When an agent receives a Binding response, it uses the transaction
+ID <xref target="RFC5389"/> to find the corresponding Binding request
+and candidate pair and then processes the Binding response according
+to the following procedures:
 </t>
+
+<section title="Success">
+
+<t>A connectivity check is successful if and only if the response is a
+success and the request and response are symmetric.  They are
+symmetric if and only if the source IP address and port of the
+response are equal to the destination IP address and port to which the
+request was sent, and the destination IP address and port of the
+response are equal to the source IP address and port from which the
+request was sent.
+</t>
+
+</section>
+
+<section title="Failure">
+    <section title="Unrecoverable STUN Response">
+      <t>The agent SHOULD set the candidate pair state to Failed if
+      the response is an unrecoverable error <xref target="RFC5389"/>)
+      or if the transaction times out.
+      </t>
+    </section>
+
+    <section title="ICMP Error">
+      <t>The agent SHOULD set the candidate pair state to Failed if
+      the Binding request generates an ICMP error.
+      </t>
+    </section>
+
+    <section title="Non-Symmetric Transport Addresses">
+      <t>The agent MUST set the candidate pair state to Failed if the
+      request and response are not symmetric.  
+      </t>
+    </section>
+
+    <t>NOTE: When the agent sets the candidate pair state to Failed as
+    a result of a connectivity check error, the agent does not change
+    the states of other candidate pairs.
+    </t>
+</section>
+
+
 <section title="Role Conflict">
-    <t>If the Binding request generates a 487 (Role Conflict) error
-    response, and if the ICE agent included an ICE-CONTROLLED attribute
-    in the request, the agent MUST switch to the controlling role. If
-    the ICE agent included an ICE-CONTROLLING attribute in the request,
-    the agent MUST switch to the controlled role.
-    </t>
-    <t>Once the ICE agent has switched its role, the agent MUST add the
-    candidate pair whose check generated the 487 error response to the
-    triggered check queue associated with the check list to which the
-    pair belongs, and set the candidate pair state to Waiting. When the
-    triggered connectivity check is later performed, the
-    ice-controlling/ice-controlled attribute of the Binding request will
-    indicate the agent's new role. The ICE agent MUST NOT change
-    the tie-breaker value.
-    </t>
-    <t>NOTE: A role switch requires an ICE agent to recompute pair priorities
-    (<xref target="sec-comp-pair-prio"/>), since the priority values
+    <t>If the response is a 487 (Role Conflict) error, the agent MUST
+    switch its role according the attributes in the request and add
+    the candidate pair to the triggered check queue and set the pair
+    state to Waiting. If the request included an ICE-CONTROLLED
+    attribute the agent MUST switch to the controlling role.  If the
+    request included an ICE-CONTROLLING attribute, the agent MUST
+    switch to the controlled role.  The ICE agent MUST NOT change the
+    tie-breaker value. After switching roles, the agent MUST recompute
+    pair priorities (<xref target="sec-comp-pair-prio"/>) since they
     depend on the role.
     </t>
+
     <t>NOTE: A role switch will also impact whether the ICE agent is responsible
     for nominating candidate pairs, and whether the agent is responsible
     for initiating the exchange of the updated candidate information with
     the peer once ICE is concluded.
     </t>
 </section>
-<section title="Failure">
-    <t>This section describes cases when the candidate pair state is set to Failed.
-    </t>
-    <t>NOTE: When the ICE agent sets the candidate pair state to Failed as a
-    result of a connectivity check error, the agent does not change the states
-    of other candidate pairs with the same foundation.
-    </t>
-    <section title="Non-Symmetric Transport Addresses">
-    <t>The ICE agent MUST check that the source and destination transport addresses
-    in the Binding request and response are symmetric. I.e., the source IP address
-    and port of the response MUST be equal to the destination IP address and port to which the
-    Binding request was sent, and that the destination IP address and port of the response
-    MUST be equal to the source IP address and port from which the Binding request was sent.
-    If the addresses are not symmetric, the ICE agent MUST set the candidate pair state
-    to Failed.
-    </t>
-    </section>
-    <section title="ICMP Error">
-    <t>An ICE agent MAY support processing of ICMP errors for connectivity
-    checks. If the agent supports processing of ICMP errors, and if a Binging
-    request generates an ICMP error, the agent SHOULD set the state of the candidate
-    pair to Failed.
-    </t>
-    </section>
-    <section title="Unrecoverable STUN Response">
-    <t>If the Binding request generates a STUN error response that is
-    unrecoverable <xref target="RFC5389"/>) or times out, the ICE agent SHOULD set
-    the candidate pair state to Failed.
-    </t>
-    </section>
-</section>
-
-<section title="Success">
-
-<t>A connectivity check is considered a success if each of the following criteria
-is true:
-<list style="symbols">
-<t>The Binding request generated a success response; and</t>
-<t>The source and destination transport addresses in the Binding
-request and response are symmetric.</t>
-</list></t>
 
 <section anchor="sec-learn-peer-client" title="Discovering Peer Reflexive Candidates">
 
-<t>The ICE agent MUST check the mapped address from the STUN
-response. If the transport address does not match any of the local
-candidates, the mapped address represents a new peer reflexive
-candidate which is added to the corresponding check list.
-The type, base, priority, and foundation are computed as follows.
+<t>The agent MUST check the mapped address in the response. If
+the transport address does not match any of the local candidates, the
+mapped address represents a new peer reflexive candidate which is
+added to the corresponding check list.  The type, base, priority, and
+foundation are computed as follows.
 </t>
 
 <t><list style="symbols">
@@ -1785,10 +1776,10 @@ the Binding request.</t>
 <t>The foundation is described in <xref target="sec-computing-foundations"/>.</t>
 </list></t>
 
-<t>The ICE agent does not need to pair the peer reflexive
+<t>The agent does not need to pair the peer reflexive
 candidate with remote candidates, as a valid candiate pair will be
 created due to the procedures in <xref target="sec-valid-cons"/>.
-If an ICE agent wishes to pair the peer reflexive candidate with
+If an aagent wishes to pair the peer reflexive candidate with
 remote candidates other than the one in the valid pair that will
 be generated, the agent MAY provide updated candidate information to
 the peer that includes the peer reflexive candidate. This will cause
@@ -1802,14 +1793,13 @@ mapped address of the response, and whose remote candidate equals the
 destination address to which the request was sent. This is called a
 valid pair.
 </t>
-<t>The valid pair may equal the pair that generated the connectivity
-check, or equal a different pair (perhaps in a different check list),
-or not equal any pair in any check list.
-</t>
+
 <t>For each check list, the agent maintains a list of valid pairs.
 This list is called the VALID LIST and is initially empty.  The valid
 list tracks whether or not a valid pair in it has been nominated or
-not.  This state is called the the Nominated Flag and is intially false.
+not, which means that valid pair SHOULD be used for sending media
+unless the sending agent detects that the candidate pair does not work
+This state is called the the Nominated Flag and is intially false.
 </t>
 
 <t>The agent adds a valid pair to a valid list as follows:
@@ -1821,69 +1811,50 @@ the valid list associated with the check list to which the pair belongs; or
 to the valid list associated with the check list of that pair. The pair that
 generated the check is not added to a valid list; or
 </t>
-<t>If the valid pair is not in any check list, the agent computes the priority
-for the pair based on the priority of each candidate, using the
-algorithm in <xref target="sec-forming"/>. The priority of the local
-candidate depends on its type. Unless the type is peer reflexive, the
-priority is equal to the priority signaled for that candidate in the candidate
-exchange. If the type is peer reflexive, it is equal to the PRIORITY
-attribute the agent placed in the Binding request that just
-completed. The priority of the remote candidate is taken from the
-candidate information of the peer. If the candidate does not appear
-there, then the check must have been a triggered check to a new remote
-candidate. In that case, the priority is taken as the value of the
+<t>If the valid pair is not in any check list, the agent computes the
+priority for the pair based on the priority of each candidate, using
+the algorithm in <xref target="sec-forming"/> and the pair is added to
+the valid list. If the local candidate is peer reflexive, the
+priority used in the algorithm for it is that of the PRIORITY
+attribute from the Binding request that just completed.  If the remote
+candidate's priority is not known from the exchanged candidate
+information, the priority used in the algorithm for it is that of the
 PRIORITY attribute in the Binding request that triggered the check
-that just completed. The pair is then added to the valid list.
+that just completed.  Otherwise, the priorities used come from the
+exchanged candidate information.
 </t>
 </list></t>
-<t>NOTE: It will be very common that the valid pair will not be in any check list.
-Recall that the check list has pairs whose local candidates are never
-reflexive; those pairs had their local candidates converted to
-the base of the reflexive candidates, and then pruned if they
-were redundant. When the response to the Binding request arrives, the
-mapped address will be reflexive if there is a NAT between the two. In
-that case, the valid pair will have a local candidate that doesn't
-match any of the pairs in the check list.
-</t>
+
 </section>
 
 
 <section title="Updating Candidate Pair States">
-<t>The ICE agent sets the state of both the candidate pair that generated
-the check, and the constructed valid pair, to Succeeded.
-Note that the pair which generated the check may be different than the
-valid pair constructed in <xref target="sec-valid-cons"/>.
+<t>The agent sets the states of both the candidate pair that generated
+the check and the constructed valid pair (which may be different) to
+Succeeded.
 </t>
-<t>The success of the connectivity check might also cause the state of other
-candidate pairs to change. The ICE agent MUST set the states for all other
-Frozen candidate pairs (in each check list in the check list set) with
-the same foundation to Waiting.
-</t>
-<t>NOTE: Within a given check list, candidate pairs with the same foundations will
-typically have different component ID values.
+<t>The agent MUST set the states for all other Frozen candidate pairs
+in all check lists with the same foundation to Waiting.
 </t>
 </section>
 
 <section title="Updating the Nominated Flag">
 
-<t>If the ICE agent was a controlling agent, and the agent had included a
-USE-CANDIDATE attribute in the Binding request, the valid pair
-generated from that check has its nominated flag value set to true. This
-flag indicates that this valid pair SHOULD be used for media, unless
-the sending agent detects that the candidate pair does not work.
-This concludes the ICE processing for this media stream or all
-media streams; see <xref target="sec-conclude"/>.
+<t>If the request had included a USE-CANDIDATE attribute in the
+Binding request, the controlling agent sets the Nominated Flag of the
+valid pair to true.  This concludes the ICE processing for this media
+stream; see <xref target="sec-conclude"/>.
 </t>
 
-<t>If the ICE agent is the controlled agent, the response may be the result
-of a triggered check that was sent in response to a request that
-itself had the USE-CANDIDATE attribute. This case is described in
-<xref target="sec-up-fav"/>, and may now result in setting the
-nominated flag for the pair learned from the original request.
+<t>If the response was the result of a triggered check that was sent
+in response to a request that itself had the USE-CANDIDATE attribute,
+the controlled agent may now set the Nominated Flag for the pair
+learned from the original request.  This case is described in <xref
+target="sec-up-fav"/>.
 </t>
 
 <t>An ICE agent MUST NOT select a candidate pair until it has sent a
-Binding request, and received the corresponding Binding response,
+Binding request and received the corresponding Binding response
 associated with the candidate pair.
 </t>
 

--- a/draft-ietf-ice-rfc5245bis.xml
+++ b/draft-ietf-ice-rfc5245bis.xml
@@ -1812,19 +1812,17 @@ mapped address of the response, and whose remote candidate equals the
 destination address to which the request was sent. This is called a
 valid pair.
 </t>
-<t>The valid pair may equal the pair that generated the connectivity check, or
-it may equal a different pair in a check list (sometimes in a different check list
-than the one to which the pair that generated the connectivity checks),
-or it may be a pair not currently in any check list.
+<t>The valid pair may equal the pair that generated the connectivity
+check, or equal a different pair (perhaps in a different check list),
+or not equal any pair in any check list.
 </t>
-<t>The ICE agent maintains a separate list, called the VALID LIST, for each check
-list in the check list set. The valid list will contain valid pairs. Initially
-each valid list is empty.
+<t>For each check list, the agent maintains a list of valid pairs.
+This list is called the VALID LIST and is initially empty.  The valid
+list tracks whether or not a valid pair in it has been nominated or
+not.  This state is called the the Nominated Flag and is intially false.
 </t>
-<t>Each valid pair within the valid list has a flag, called the Nominated Flag.
-When a valid pair is added to a valid list, the flag value is set to 'false'.
-</t>
-<t>The valid pair will be added to a valid list as follows:
+
+<t>The agent adds a valid pair to a valid list as follows:
 <list style="numbers">
 <t>If the valid pair equals the pair that generated the check, the pair is added to
 the valid list associated with the check list to which the pair belongs; or

--- a/draft-ietf-ice-rfc5245bis.xml
+++ b/draft-ietf-ice-rfc5245bis.xml
@@ -1211,14 +1211,24 @@ check list.
 <section title="Check List State">
 <t>Each check list has one of the following states:</t>
 <t><list style="hanging">
-<t hangText="Running:">Not yet in the Completed or Failed state.
+
+<t hangText="Running:">The check list is neither Completed yet nor
+Failed yet.  This means that at least one component of the check list
+does not have a selected candidate pair and that no component of the
+check list has candidate pairs that are all in the Failed state.
 </t>
-<t hangText="Completed:"> The agent has a selected pair for each
-component of the media stream.
+
+<t hangText="Completed:">The check list has a selected candidate pair
+for each component of the media stream.
 </t>
-<t hangText="Failed:">For any component of the media stream, all
-candidate pairs are in the Failed state.
+
+<t hangText="Failed:">The check list does not have a valid candidate
+pair for each component of the media stream and all of the candidate
+pairs in the check list are in either the Failed or Succeeded state.
+In other words, at least one component of the check list has candidate
+pairs that are all in the Failed state.
 </t>
+
 </list></t>
 <t>Additionally, a check list with at least one pair in the waiting
 state is called "active", while a check list with all pairs in the
@@ -1511,11 +1521,11 @@ foundation in the check list set has been placed in the Waiting state.
 </section>
 </section>
 
-<section title="ICE State">
+<section anchor="sec-state" title="ICE State">
 <t>
 The ICE agent has a state determined by the state of the check
 lists. The state is Completed if all check lists are Completed, Failed
-if any check list is Failed, and Running otherwise.
+if all check lists are Failed, and Running otherwise.
 </t>
 </section>
 
@@ -1653,7 +1663,8 @@ until ICE concludes.
 
 <section title="Forming Credentials">
 <t>A connectivity check Binding request MUST utilize the STUN
-short-term credential mechanism.
+short-term credential mechanism (i.e., the MESSAGE-INTEGRITY
+attribute).
 </t>
 <t>The username for the credential is formed by concatenating the
 username fragment provided by the peer with the username fragment of
@@ -1737,7 +1748,6 @@ request was sent.
     </t>
 </section>
 
-
 <section title="Role Conflict">
     <t>If the response is a 487 (Role Conflict) error, the agent MUST
     switch its role according the attributes in the request and add
@@ -1746,15 +1756,16 @@ request was sent.
     attribute the agent MUST switch to the controlling role.  If the
     request included an ICE-CONTROLLING attribute, the agent MUST
     switch to the controlled role.  The ICE agent MUST NOT change the
-    tie-breaker value. After switching roles, the agent MUST recompute
-    pair priorities (<xref target="sec-comp-pair-prio"/>) since they
-    depend on the role.
+    tie-breaker value.
     </t>
 
-    <t>NOTE: A role switch will also impact whether the ICE agent is responsible
-    for nominating candidate pairs, and whether the agent is responsible
-    for initiating the exchange of the updated candidate information with
-    the peer once ICE is concluded.
+    <t>
+      A change in roles will require an agent to recompute pair
+      priorities (<xref target="sec-comp-pair-prio"/>), since those
+      priorities are a function of role. The change in role will also
+      impact whether the agent is responsible for selecting nominated
+      pairs and initiating exchange with updated candidate information
+      upon conclusion of ICE.
     </t>
 </section>
 
@@ -1771,7 +1782,7 @@ foundation are computed as follows.
 <t>The type is peer reflexive.</t>
 <t>The base is local candidate of the candidate pair
 from which the Binding request was sent.</t>
-<t>The priority is value of the PRIORITY attribute in
+<t>The priority is the value of the PRIORITY attribute in
 the Binding request.</t>
 <t>The foundation is described in <xref target="sec-computing-foundations"/>.</t>
 </list></t>
@@ -1779,7 +1790,7 @@ the Binding request.</t>
 <t>The agent does not need to pair the peer reflexive
 candidate with remote candidates, as a valid candiate pair will be
 created due to the procedures in <xref target="sec-valid-cons"/>.
-If an aagent wishes to pair the peer reflexive candidate with
+If an agent wishes to pair the peer reflexive candidate with
 remote candidates other than the one in the valid pair that will
 be generated, the agent MAY provide updated candidate information to
 the peer that includes the peer reflexive candidate. This will cause
@@ -1866,17 +1877,12 @@ associated with the candidate pair.
 
 <section title="Check List State Updates">
 <t>
-Regardless of whether a connectivity check was successful or failed, the
-completion of the check may require updating of check list states.
-For each check list in the check list set, if all of the candidate pairs
-are in either Failed or Succeeded state, and if there is not a valid pair in
-the valid list for each component of the media stream associated with the
-check list, the state of the check list is set to Failed. If there is a
-valid pair for each component in the valid list, the state of the check
-list is set to Succeeded.
+The completion of a check (either successful or failed) may require
+updating check list states according to the definitions in <xref
+target="sec-forming"/>.
 </t>
 </section>
-</section>
+
 <!-- end processing response -->
 </section>
 
@@ -1884,44 +1890,34 @@ list is set to Succeeded.
 <section anchor="sec-serverproc" title="STUN Server Procedures">
 
 <t>
-An agent MUST be prepared to receive a Binding request on the base of
-each candidate it included in its most recent candidate exchange. This
-requirement holds even if the peer is a lite implementation.
+An agent (lite or full) MUST be prepared to receive Binding requests
+on the base of each candidate it included in its most recent candidate
+exchange.
 </t>
 
 <t>
-The agent MUST use the short-term credential mechanism (i.e., the
-MESSAGE-INTEGRITY attribute) to authenticate the request and perform a
-message integrity check. Likewise, the short-term credential mechanism
-MUST be used for the response. The agent MUST consider the username to
-be valid if it consists of two values separated by a colon, where the
-first value is equal to the username fragment generated by the agent
-in an candidate exchange for a session in-progress. It is possible
-(and in fact very likely) that the initiating agent will receive a
-Binding request prior to receiving the candidates from its peer. If
-this happens, the agent MUST immediately generate a response
-(including computation of the mapped address as described in <xref
-target="sec-compute-mapped"/>). The agent has sufficient information
-at this point to generate the response; the password from the peer is
-not required. Once the answer is received, it MUST proceed with the
-remaining steps required, namely, <xref
-target="sec-learn-peer-server"/>, <xref target="sec-triggered"/>, and
-<xref target="sec-up-fav"/> for full implementations. In cases where
-multiple STUN requests are received before the answer, this may cause
-several pairs to be queued up in the TRIGGERED CHECK QUEUE.
+A Binding response MUST utilize the STUN short-term credential
+mechanism (i.e., the MESSAGE-INTEGRITY attribute).  The username is
+considered valid if and only if it consists of two values separated by
+a colon, where the first value is equal to the username fragment
+generated by the agent in a candidate exchange for a session
+in-progress.  An agent MUST NOT utilize the ALTERNATE-SERVER
+mechanism, and MUST NOT support the backwards-compatibility mechanisms
+of RFC 3489. It MUST utilize the FINGERPRINT mechanism.
 </t>
 
 <t>
-An agent MUST NOT utilize the ALTERNATE-SERVER mechanism, and MUST NOT
-support the backwards-compatibility mechanisms to RFC 3489. It MUST
-utilize the FINGERPRINT mechanism.
+If the initiating agent receives Binding requests before receiving
+candidates, it MUST generate responses, including computation of the
+mapped address as described in <xref
+target="sec-compute-mapped"/>). 
 </t>
 
 <t>
 If the agent is using Diffserv Codepoint markings <xref
-target="RFC2475"/> in its media packets, it SHOULD apply those same
-markings to its responses to Binding requests. The same would apply to
-any layer 2 markings the endpoint might be applying to media packets.
+target="RFC2475"/> in its media packets, it SHOULD apply the same
+markings to Binding responses. The same would apply to any layer 2
+markings the endpoint might be applying to media packets.
 </t>
 
 <section anchor="sec-add-server-full" title="Additional Procedures for Full Implementations">
@@ -1932,14 +1928,10 @@ to full implementations.
 
 <section anchor="sec-role-conflict" title="Detecting and Repairing Role Conflicts">
 <t>
-Normally, the rules for selection of a role in <xref target="sec-role"/>
-will result in each agent selecting a different role -- one controlling
-and one controlled. However, in unusual call flows, typically utilizing
-third party call control, it is possible for both agents to select the
-same role. This section describes procedures for checking for this case
-and repairing it. These procedures apply only to usages of ICE that
-require conflict resolution. The usage document MUST specify whether this
-mechanism is needed.
+In certain usages of ICE, both agents may end up choosing the same
+role, resulting in a role conflict.  The section describes a mechanism
+for detetecing and repairing role conflicts.  The usage document
+MUST specify whether this mechanism is needed.
 </t>
 
 <t>
@@ -1990,27 +1982,19 @@ Conflict) but retains its role.
 </list>
 </t>
 
-<t>
-If the agent is in the controlled role and the ICE-CONTROLLING
-attribute was present in the request, or the agent was in the
-controlling role and the ICE-CONTROLLED attribute was present in the
-request, there is no conflict.
-</t>
-
 </list></t>
 
 <t>
 A change in roles will require an agent to recompute pair priorities
 (<xref target="sec-comp-pair-prio"/>), since those priorities are a
-function of controlling and controlled roles. The change in role will
-also impact whether the agent is responsible for selecting nominated
-pairs and initiating exchange with updated candidate information
-upon conclusion of ICE.
+function of role. The change in role will also impact whether the
+agent is responsible for selecting nominated pairs and initiating
+exchange with updated candidate information upon conclusion of ICE.
 </t>
 
 <t>
 The remaining sections in <xref target="sec-add-server-full"/> are
-followed if the server generated a successful response to the Binding
+followed if the agent generated a successful response to the Binding
 request, even if the agent changed roles.
 </t>
 
@@ -2020,7 +2004,7 @@ request, even if the agent changed roles.
 <section anchor="sec-compute-mapped" title="Computing Mapped Address">
 
 <t>
-For requests being received on a relayed candidate, the source
+For requests received on a relayed candidate, the source
 transport address used for STUN processing (namely, generation of the
 XOR-MAPPED-ADDRESS attribute) is the transport address as seen by the
 TURN server. That source transport address will be present in the
@@ -2038,17 +2022,18 @@ source transport address is the one that was bound to the channel.
 If the source transport address of the request does not match any
 existing remote candidates, it represents a new peer reflexive remote
 candidate. This candidate is constructed as follows:
+
 <list style="symbols">
-<t>The priority of the candidate is set to the PRIORITY attribute from
-the request.</t>
-<t>The type of the candidate is set to peer reflexive. </t>
-<t>The foundation of the candidate is set to an arbitrary value,
-different from the foundation for all other remote candidates. If any
+<t>The type is peer reflexive.</t>
+<t>The priority is the value of the PRIORITY attribute in
+the Binding request.</t>
+<t>The component ID is the component ID of
+the local candidate to which the request was sent.
+<t>The foundation is an arbitrary value,
+different from the foundations of all other remote candidates. If any
 subsequent candidate exchanges contain this peer reflexive
 candidate, it will signal the actual foundation for the
 candidate.</t>
-<t>The component ID of this candidate is set to the component ID for
-the local candidate to which the request was sent.
 </t>
 </list>
 </t>
@@ -2062,78 +2047,44 @@ the agent does not pair this candidate with any local candidates.
 <section anchor="sec-triggered" title="Triggered Checks">
 
 <t>
-Next, the agent constructs a pair whose local candidate is equal to
-the transport address on which the STUN request was received, and a
-remote candidate equal to the source transport address where the
-request came from (which may be the peer reflexive remote candidate
-that was just learned). The local candidate will either be a host
-candidate (for cases where the request was not received through a
-relay) or a relayed candidate (for cases where it is received through
-a relay).  The local candidate can never be a server reflexive
-candidate. Since both candidates are known to the agent, it can obtain
-their priorities and compute the candidate pair priority. This pair is
-then looked up in the check list. There can be one of several
-outcomes:
+If the check list does not already contain a candidate pair with a
+local candidate equal to the transport address on which the Binding
+request was received and a remote candidate equal to the source
+transport address where the request came from, the agent MUST
+insert such a candidate pair into the check list (based on its
+priority, and with a state of Waiting).  It then uses the candidate pair,
+whether it existed previously or was just inserted, according the
+following rules:
 
 <list style="symbols">
-  <t>If the pair is already on the check list:
-    <list style="symbols">
-      <t>If the state of that pair
-      is Waiting or Frozen, a check for that pair is enqueued into the
-      TRIGGERED CHECK QUEUE if not already present.
-      </t>
-
-      <t>If the state of that pair is In-Progress, the agent cancels
-      the in-progress transaction. Cancellation means that the agent
-      will not retransmit the request, will not treat the lack of
-      response to be a failure, but will wait the duration of the
-      transaction timeout for a response. In addition, the agent MUST
-      create a new connectivity check for that pair (representing a
-      new STUN Binding request transaction) by enqueueing the pair in
-      the TRIGGERED CHECK QUEUE. The state of the pair is then changed
-      to Waiting.
-      </t>
-
-      <t> If the state of the pair is Failed, it is changed to Waiting
-      and the agent MUST create a new connectivity check for that pair
-      (representing a new STUN Binding request transaction), by
-      enqueueing the pair in the TRIGGERED CHECK QUEUE.
-      </t>
-
-      <t>If the state of that pair is Succeeded, nothing further is
-      done. </t>
-    </list>
+  <t>If the pair state is Waiting or Frozen, the agent adds the pair to the
+  triggered check queue if it is not already in it.
   </t>
+
+  <t>If the pair state is Failed, the agent adds the pair to the the
+  triggered check queue and sets the state of the pair to Waiting.
+  </t>
+
+  <t>If the pair state is In-Progress, the agent cancels the in-progress
+  transaction (meaning the agent will not retransmit the request, will
+  not treat the lack of response to be a failure, and will wait the
+  duration of the transaction timeout for a response) and adds the
+  pair to the the triggered check queue and sets the state of the pair
+  to Waiting.
+  </t>
+
+  <t>If the state is Succeeded, nothing further is done. </t>
 </list>
 </t>
 
 <t>
-These steps are done to facilitate rapid completion of ICE when both
-agents are behind NAT.
-
-<list style="symbols">
-  <t>If the pair is not already on the check list:
-  <list style="symbols">
-    <t>The pair is inserted into the check list based on its priority.</t>
-    <t>Its state is set to Waiting.</t>
-    <t>The pair is enqueued into the TRIGGERED CHECK QUEUE. </t>
-  </list>
-  </t>
-</list>
-
-</t>
-
-<t>
-When a triggered check is to be sent, it is constructed and processed
-as described in <xref
-target="sec-send-check"/>target="sec-connectivity_check"/>. These
-procedures require the agent to know the transport address, username
-fragment, and password for the peer. The username fragment for the
-remote candidate is equal to the part after the colon of the USERNAME
-in the Binding request that was just received. Using that username
-fragment, the agent can check the candidates received from its peer
-(there may be more than one in cases of forking), and find this
-username fragment. The corresponding password is then selected.
+When a triggered check is sent, it is constructed and processed as
+described in <xref
+target="sec-send-check"/>target="sec-connectivity_check"/>.  The
+username fragment for the remote candidate is the part after the colon
+of the USERNAME attribute in the Binding request that was just
+received.  The password is known from the candidates received from the
+peer corresponding to the username fragment.
 </t>
 
 <!-- end triggered checks -->
@@ -2142,23 +2093,13 @@ username fragment. The corresponding password is then selected.
 <section anchor="sec-up-fav" title="Updating the Nominated Flag">
 
 <t>
-If the Binding request received by the agent had the USE-CANDIDATE
-attribute set, and the agent is in the controlled role, the agent
-looks at the state of the pair computed in <xref target="sec-triggered"/>:
-<list style="symbols">
-<t>If the state of this pair is Succeeded, it means that the check
-generated by this pair produced a successful response. This would have
-caused the agent to construct a valid pair when that success response
-was received (see <xref target="sec-valid-cons"/>). The agent now sets
-the nominated flag value of the valid pair to true. This may end ICE
-processing for this media stream; see <xref target="sec-conclude"/>.
-</t>
-<t>If the state of this pair is In-Progress, and if its check produces a
-successful result, the resulting valid pair has its nominated flag set
-when the response arrives. This may end ICE processing for this media
-stream when it arrives; see <xref target="sec-conclude"/>.
-</t>
-</list>
+After a controlled agent receives a Binding request with the
+USE-CANDIDATE attribute on a candidate pair and a valid pair has been
+constructed for that candidate pair, the controlled agent MUST set the
+Nominated Flag of the valid pair to true.  Either event may happen
+first, but the agent does not set the flag until both have
+occurred.  This may end ICE processing for this media stream; see
+<xref target="sec-conclude"/>.
 </t>
 
 </section>
@@ -2169,15 +2110,12 @@ stream when it arrives; see <xref target="sec-conclude"/>.
 <section title="Additional Procedures for Lite Implementations">
 
 <t>
-If the check that was just received contained a USE-CANDIDATE
-attribute, the agent constructs a candidate pair whose local candidate
-is equal to the transport address on which the request was received,
-and whose remote candidate is equal to the source transport address of
-the request that was received. This candidate pair is assigned an
-arbitrary priority, and placed into a list of valid candidates called
-the valid list. The agent sets the nominated flag for that pair to
-true. ICE processing is considered complete for a media stream if the
-valid list contains a candidate pair for each component.
+If a lite agent receives a Binding request with the USE-CANDIDATE
+attribute, the agent constructs a valid candidate pair with local
+candidate equal to the transport address on which the request was
+received, and remote candidate equal to the source transport address
+of the request that was received and adds it to the valid list (if it
+is not already in the valid list) and sets the Nominated Flag to true.
 </t>
 
 </section>
@@ -2204,121 +2142,60 @@ updating of state machinery.
 
 <section anchor="sec-choose-favor" title="Nominating Pairs">
 
-<t>Prior to nominating, the agent let connectivity quecks continue until
-some stopping criterion is met. After that, based on an evaluation
-criterion, the agent selects a pair among the valid pairs in the valid list
-for nomination.
+<t>This section applies within the context of a single component of a
+single media stream.</t>
+
+<t>The controlling agent stops connectivity checks when some stopping
+criterion is met (outside the scope of this document). It then selects
+a valid candidate pair based on some selection criterion (outside the
+scope of this document).  It then sends a connectivity check with the
+USE-CANDIDATE attribute on the selected candidate pair by enqueuing
+the selected candidate pair in the triggered check queue.  The
+controlling agent MUST NOT nominate more than one candidate pair.
 </t>
-<t>Once the controlling agent has selected a valid pair for nomination, it
-repeats the connectivity check that produced this valid pair (by enqueueing
-the pair that generated the check into the TRIGGERED CHECK QUEUE), this time with
-the USE-CANDIDATE attribute. The connectivity check should succeed (since the
-previous did), causing the nominated flag value of that and only that pair
-to be set to true.
+
+<t>The controlled agent SHOULD select the nominated candidate
+pair. But before a candidate pair has been selected, the controlled
+agent may send media on any valid candidate pair.
 </t>
-<t>Eventually, there will be only a single nominated pair in the valid list for
-each component. Once the state of the check list is set to Completed, that exact
-pair is selected by ICE for sending and receiving media for that component.
+
+<t>After selecting a candidate pair, the agent MUST remove all Waiting
+and Frozen pairs from the check list and triggered check queue.
+The agent SHOULD cease retransmissions of checks from In-Progress
+candidate pairs thar are of lower priority than the selected candidate pair.
 </t>
-<t>The criterion details for stopping the connectivity checks and for
-selecting a pair for nomiation, are outside the scope of this specification.
-They are a matter of local optimization. The only requirement is that the
-agent MUST eventually pick one and only one candidate pair and generate a
-check for that pair with the USE-CANDIDATE attribute present.
+
+<t>If a check list is Completed (for all components of the check
+list), the agent MUST continue to respond to any checks it may
+still receive for that media stream, perform triggered checks if
+required by the processing of <xref target="sec-serverproc"/>, and
+continue retransmitting any In-Progress checks for that check list.
 </t>
-<t>The controlled agent SHOULD select the candidate pair nominated by the
-controlling agent if the controlled agent is receiving Binding responses
-associated with that candidate pair. Before the agent has received Binding
-responses associated with the candidate pair, the agent can send media on
-any candidate for which it has received Binding responses.
-</t>
-<t>If more than one candidate pair is nominated by the controlling agent, the
-controlled agent SHOULD select the candidate pair with the highest priority.
-</t>
+
 <t>
-NOTE: A controlling agent that does not support this specification (i.e. it
-is implemented according to RFC 5245) might nominate more than one candidate pair.
-This was referred to as aggressive nomination in RFC 5245. The usage of the
-'ice2' ice option by endpoints supporting this specifcation should prevent
-such controlling agents from using aggressive nomination.
+A controlling agent that does not support this specification (i.e. it
+is implemented according to RFC 5245) might nominate more than one
+candidate pair.  This was referred to as aggressive nomination in RFC
+5245. The usage of the 'ice2' ice option by endpoints supporting this
+specifcation should prevent such controlling agents from using
+aggressive nomination.  But if more than one candidate pair is
+nominated by the controlling agent, the controlled agent SHOULD select
+the candidate pair with the highest priority.
 </t>
 
 </section>
 
 <section anchor="sec-conc-state" title="Updating States">
 
-<t>
-For both controlling and controlled agents, the state of ICE
-processing depends on the presence of nominated candidate pairs in the
-valid list and on the state of the check list. Note that, at any time,
-more than one of the following cases can apply:
-</t>
+<t>If some of the the check lists are Completed and some are Failed
+and all are either Completed or Failed, remove the failed media
+streams and send an updated candidate list to the peer.  All checks
+lists are now Completed.</t>
 
-<t><list style="symbols">
+<t>If all check lists are Completed, the agent is Completed. </t>
 
-<t>If there are no nominated pairs in the valid list for a media
-stream and the state of the check list is Running, ICE processing
-continues.
-</t>
-
-
-<t>If there is at least one nominated pair in the valid list for a
-media stream and the state of the check list is Running:
-<list style="symbols">
-<t>The agent MUST remove all Waiting and Frozen pairs in the CHECK
-LIST and TRIGGERED CHECK QUEUE for the same component as the nominated
-pairs for that media stream.
-</t>
-<t>If an In-Progress pair in the check list is for the same component
-as a nominated pair, the agent SHOULD cease retransmissions for its
-check if its pair priority is lower than the lowest-priority nominated
-pair for that component.
-</t>
-</list>
-</t>
-
-<t>Once there is at least one nominated pair in the valid list for
-every component of at least one media stream and the state of the
-check list is Running:
-<list style="symbols">
-<t>The agent MUST change the state of processing for its check list
-for that media stream to Completed. </t>
-<t>The agent MUST continue to respond to any checks it may still
-receive for that media stream, and MUST perform triggered checks if
-required by the processing of <xref target="sec-serverproc"/>.
-</t>
-<t>The agent MUST continue retransmitting any In-Progress checks for
-that check list.</t>
-<t>The agent MAY begin transmitting media for this media stream as
-described in <xref target="sec-send-media"/>.
-</t>
-</list>
-</t>
-
-<t>Once the state of each check list is Completed:
-<list style="symbols">
-<t>The agent sets the state of ICE processing overall to Completed.</t>
-</list>
-</t>
-
-<t>If the state of the check list is Failed, ICE has not been
-able to complete for this media stream. The correct behavior depends
-on the state of the check lists for other media streams:
-<list style="symbols">
-<t>If all check lists are Failed, ICE processing overall is considered
-to be in the Failed state, and the agent SHOULD consider the session a
-failure, SHOULD NOT restart ICE, and the controlling agent SHOULD
-terminate the entire session. </t>
-<t>If at least one of the check lists for other media streams is
-Completed, the controlling agent SHOULD remove the failed media stream
-from the session while sending updated candidate list to its peer.</t>
-<t> If none of the check lists for other media streams are
-Completed, but at least one is Running, the agent SHOULD let ICE
-continue.</t>
-</list>
-</t>
-
-</list></t>
+<t>If all check lists are Failed, the agent is Failed and SHOULD NOT
+restart ICE. </t>
 
 </section>
 
@@ -2327,42 +2204,19 @@ continue.</t>
 <section anchor="sec-lite-conclude" title="Procedures for Lite Implementations">
 
 <t>
-Concluding ICE for a lite implementation is relatively
-straightforward. There are two cases to consider:
-<list style="empty">
-<t>The implementation is lite, and its peer is full. </t>
-<t>The implementation is lite, and its peer is lite. </t>
-</list></t>
-
-<t>
-The effect of ICE concluding is that the agent can free any allocated
-host candidates that were not utilized by ICE, as described in <xref
-target="sec-freeing"/>.
-</t>
-
-<section title="Peer Is Full">
-
-<t>
-In this case, the agent will receive connectivity checks from its
-peer. When an agent has received a connectivity check that includes
-the USE-CANDIDATE attribute for each component of a media stream, the
-state of ICE processing for that media stream moves from Running to
-Completed. When the state of ICE processing for all media streams is
-Completed, the state of ICE processing overall is Completed.
+When ICE concludes, a lite agent can free host candidates that were
+not used by ICE, as described in <xref target="sec-freeing"/>.
 </t>
 
 <t>
-The lite implementation will never itself determine that ICE
-processing has failed for a media stream; rather, the full peer will
-make that determination and then remove or restart the failed media
-stream as part of subsequent candidate exchange process.
+If the peer is a full agent, the lite agent selects a candidate pair
+when the full agent nominates it.  When the lite agent has selected a
+candidate pair for all components of all media streams, it is
+Completed.
 </t>
 
-</section>
-
-<section anchor="sec-lite-conc2" title="Peer Is Lite">
-
 <t>
+If the peer is a lite agent, 
 Once the candidate exchange has completed, both agents examine their
 candidates and those of its peer. For each media stream, each agent
 pairs up its own candidates with the candidates of its peer for that

--- a/draft-ietf-ice-rfc5245bis.xml
+++ b/draft-ietf-ice-rfc5245bis.xml
@@ -2272,49 +2272,31 @@ sending checks and resposnes from it.
 
 <section anchor="sec-restart" title="ICE Restarts">
 <t>
-An agent MAY restart ICE processing for an existing media stream.
-An ICE restart will cause all previous states, excluding the roles
-of the agents, of ICE processing to be flushed and checks to start anew.
-The only difference between an ICE restart and a brand new media session
-is that during the restart media can continue to be sent to the
-previously validated pair, and that a new media session always requires
-the roles to be determined.
+An agent MAY restart ICE for existing media streams.  An ICE restart
+causes all previous state of the media streams, excluding the roles of
+the agents to be flushed.  The only difference between an ICE restart
+and a brand new media session is that during the restart media can
+continue to be sent, and that a new media session always requires the
+roles to be determined.
 </t>
 
-<t>An agent MUST restart ICE for a media stream if:</t>
+<t>If an agent wants to change the destinations of media streams, it
+MAY restart ICE to do so.</t>
 
-<t>
-<list style="symbols">
-<t>
-The candidate(s) is being generated for the purposes of changing the
-target of the media stream.  In other words, if an agent wants to
-generate an updated candidate information that, had ICE not been in
-use, would result in a new value for the destination of a media
-component.
-</t>
-
-<t>
-An agent is changing its implementation level.  This typically
-only happens in third party call control use cases, where the entity
-performing the signaling is not the entity receiving the media, and it
-has changed the target of media mid-session to another entity that has
-a different ICE implementation.
-</t>
-</list>
-</t>
+<t>If an agent want to change its implmentation level, it MAY restart
+ICE to do so.</t>
 
 <t>
 To restart ICE, an agent MUST change both the password and the
-user name fragment for the media stream when exchanging the
-candidates.  The new candidate set MAY include some, none, or all of
-the previous candidates for that stream and MAY include a totally new
-set of candidates.
+username fragment for the media stream(s) being restarted.  The new
+candidate set MAY include some, none, or all of the previous
+candidates.
 </t>
 
 <t>
 As described in <xref target="sec-role"/>, ICE agents MUST NOT
 re-determine the roles as part as an ICE restart, unless certain
-criteria that require the roles to be re-determined is fulfilled.
+criteria that require the roles to be re-determined are fulfilled.
 </t>
 
 </section>
@@ -2325,14 +2307,14 @@ criteria that require the roles to be re-determined is fulfilled.
 
 <t>
 This section defines a new ICE option, 'ice2'. The ICE option
-indicates that the ICE agent that includes it (in an ice-options
-attribute) is compliant to this specification. For example, the
+indicates that the ICE agent that includes it a candidate exchange
+is compliant to this specification. For example, the
 ICE agent will not use the aggressive nomination procedure
 defined in <xref target="RFC5245"/>.
 </t>
 <t>
 An ICE agent compliant to this specification MUST inform the peer
-about the compliance using the 'ice2' ICE option.
+about the compliance using the 'ice2' option.
 </t>
 <t>
 NOTE: The encoding of the 'ice2' ICE option, and the message(s)
@@ -2347,48 +2329,33 @@ is defined in <xref target="I-D.ietf-mmusic-ice-sip-sdp"/>.
 <section anchor="sec-keepalives" title="Keepalives">
 
 <t>
-All endpoints MUST send keepalives for each media session. These
-keepalives serve the purpose of keeping NAT bindings alive for the
-media session. The keepalives SHOULD be sent using a
-format that is supported by its peer. ICE endpoints allow for
-STUN-based keepalives for UDP streams, and as such, STUN keepalives
-MUST be used when an agent is a full ICE implementation and is
-communicating with a peer that supports ICE (lite or full).
+All agents MUST send keepalives to keep NAT bindings alive.  The
+keepalives SHOULD be sent using a format that is supported by its
+peer.
 </t>
 
 <t>
-If there has been no packet sent on the candidate pair ICE is using
-for a media component for Tr seconds (where packets include those
-defined for the component (RTP or RTCP) and previous keepalives), an
-agent MUST generate a keepalive on that pair. ICE endpoints SHOULD use
-a Tr value of 15 seconds, but MAY use another value, e.g. based on
-configuration or network/NAT characteristics. For example, if
-an agent has a dynamic way to discover the binding lifetimes of the
-intervening NATs, it can use that value to determine Tr. Administrators
-deploying ICE in more controlled networking environments SHOULD set Tr
-to the longest duration possible in their environment. ICE endpoints
-MUST NOT use a Tr value smaller than 15 seconds.
+For each candidate pair that an agent is using to send media, if no
+packet has been sent on that pair in the last Tr seconds, an agent
+MUST send a keepalive on that pair.  Agents SHOULD use a Tr value of
+15 seconds. Agents MUST NOT use a Tr value smaller than 15 seconds.
+first. An agent MUST begin sending keepalives once a candidate pair is
+selected or a candidate pair is used to send media, whichever happens
+first.  An agent MUST stop sending keepalives once the session
+terminates or the media stream is removed.
 </t>
 
 <t>
-When STUN is being used for keepalives, a STUN Binding Indication is
-used <xref target="RFC5389"/>. The Indication MUST NOT utilize any
-authentication mechanism. It SHOULD contain the FINGERPRINT attribute
-to aid in demultiplexing, but SHOULD NOT contain any other
-attributes. It is used solely to keep the NAT bindings alive.  The
-Binding Indication is sent using the same local and remote candidates
-that are being used for media. Though Binding Indications are used for
-keepalives, an agent MUST be prepared to receive a connectivity check
-as well. If a connectivity check is received, a response is generated
-as discussed in <xref target="RFC5389"/>, but there is no impact on
-ICE processing otherwise.
+Full ICE agents MUST use STUN Binding Indications for keepalives <xref
+target="RFC5389"/>. The Indication MUST NOT utilize any authentication
+mechanism. It SHOULD contain the FINGERPRINT attribute to aid in
+demultiplexing, but SHOULD NOT contain any other attributes. It is
+used solely to keep the NAT bindings alive.  Though Binding
+Indications are used for keepalives, an agent MUST also respond to
+connectivity check as discussed in <xref target="RFC5389"/>.
 </t>
 
 <t>
-An agent MUST begin the keepalive processing once ICE has selected
-candidate pairs for usage with media, or media begins to flow, whichever
-happens first. Keepalives end once the session terminates or the media
-stream is removed.
 </t>
 
 </section>
@@ -2397,24 +2364,22 @@ stream is removed.
 
 <section anchor="sec-send-media" title="Sending Media">
 
+
 <t>
-Procedures for sending media differ for full and lite implementations.
+An agent MAY send media on any valid candidate pair before a candidate
+pair is selected.
 </t>
 
-<section title="Procedures for Full Implementations">
+<t>
+An agent SHOULD send media on the selected candidate pair after it is
+selected, unless the agent detects that the selected candidate pair does not
+work.
+</t>
 
 <t>
-Agents always send media using a candidate pair, using candidate pairs
-in the valid list. Once a candidate pair has been selected only that
-candidate pair (referred to as selected pair) is used for sending
-media.  Before a pair has been selected, any valid candidate pair can
-be used for sending and receiving media.  An agent will send media to
-the remote candidate (i.e., setting the destination address and port
-of the packet equal to that remote candidate), and will send it from
-the base associated with the candidate pair used for sending media. In
-case of a relayed candidate, media is sent from the agent and
-forwarded through the base (located in the TURN server), using the
-procedures defined in <xref target="RFC5766"/>.
+An agent sends media from the base of the local candidate to the
+remote candidate. In the case of a local relayed candidate, media
+forwarded through the base in the relay server.
 </t>
 
 <t>
@@ -2425,87 +2390,18 @@ defined in Section 11 of <xref target="RFC5766"/>.
 </t>
 
 <t>
-The selected pair for a component of a media stream is:
-<list style="symbols">
-<t>
-empty if the state of the check list for that media stream is Running,
-and there is no previous selected pair for that component due to an
-ICE restart
-</t>
-
-<t>
-equal to the previous selected pair for a component of a media stream
-if the state of the check list for that media stream is Running, and
-there was a previous selected pair for that component due to an ICE
-restart
-</t>
-
-</list>
-</t>
-
-<t>
 Unless an agent is able to produce a selected pair for all components
 associated with a media stream, the agent MUST NOT continue
 sending media for any component associated with that media stream.
 </t>
-
-
-
-</section>
-
-<section title="Procedures for Lite Implementations">
-
-<t>
-A lite implementation MUST NOT send media until it has a valid list
-that contains a candidate pair for each component of that media
-stream. Once that happens, the agent MAY begin sending media
-packets. To do that, it sends media to the remote candidate in the
-pair (setting the destination address and port of the packet equal to
-that remote candidate), and will send it from the base associated with the
-candidate pair used for sending media. In case of a relayed
-candidate, media is sent from the agent and forwarded through
-the base (located in the TURN server), using the procedures defined
-in <xref target="RFC5766"/>.
-</t>
-
-</section>
-
-<section title="Procedures for All Implementations">
-
-<t> ICE has interactions with jitter buffer adaptation mechanisms. An
-RTP stream can begin using one candidate, and switch to another one,
-though this happens rarely with ICE. The newer candidate may result in
-RTP packets taking a different path through the network -- one with
-different delay characteristics. As discussed below, agents are
-encouraged to re-adjust jitter buffers when there are changes in
-source or destination address of media packets. Furthermore, many
-audio codecs use the marker bit to signal the beginning of a
-talkspurt, for the purposes of jitter buffer adaptation. For such
-codecs, it is RECOMMENDED that the sender set the marker bit <xref
-target="RFC3550"/> when an agent switches transmission of media from
-one candidate pair to another.  </t>
-
-</section>
 
 </section>
 
 <section anchor="sec-recv-media" title="Receiving Media">
 
 <t>
-Even though ICE agents are only allowed to send media using valid
-candidate pairs (and, once a candidate pair has been selected, only
-on the selected pair) ICE implementations SHOULD by default be prepared
-to receive media on any of the candidates provided in the most recent
-candidate exchange with the peer. Specific ICE usages MAY define rules
-that differs from this, e.g., by defining that media must not be sent
-until selected pairs have been procduced for each component associated
-with that media.
-</t>
-
-<t>It is
-RECOMMENDED that, when an agent receives an RTP packet with a new
-source or destination IP address for a particular media stream, that
-the agent re-adjust its jitter buffers.
+Agents SHOULD be prepared to receive media on any of the candidates
+provided in the most recent candidate exchange with the peer.
 </t>
 
 <t>
@@ -2530,50 +2426,10 @@ SHOULD NOT be treated as an SSRC collision.
 <section anchor="sec-futureproof" title="Extensibility Considerations">
 
 <t>
-This specification makes very specific choices about how both agents
-in a session coordinate to arrive at the set of candidate pairs that
-are selected for media. It is anticipated that future specifications
-will want to alter these algorithms, whether they are simple changes
-like timer tweaks or larger changes like a revamp of the priority
-algorithm. When such a change is made, providing interoperability
-between the two agents in a session is critical.
-</t>
-
-<t>
-First, ICE provides the ice-options attribute. Each extension or
-change to ICE is associated with a token. When an agent supporting
-such an extension or change triggers candidate exchange, it MUST
-include the token for that extension in this attribute. This allows
-each side to know what the other side is doing. This attribute MUST
-NOT be present if the agent doesn't support any ICE extensions or
-changes.
-</t>
-
-<t>
-One of the complications in achieving interoperability is that ICE
-relies on a distributed algorithm running on both agents to converge
-on an agreed set of candidate pairs. If the two agents run different
-algorithms, it can be difficult to guarantee convergence on the same
-candidate pairs. The regular nomination procedure described in <xref
-target="sec-conclude"/> eliminates some of the tight coordination by
-delegating the selection algorithm completely to the controlling
-agent. Consequently, when a controlling agent is communicating with a
-peer that supports options it doesn't know about, the agent MUST run a
-regular nomination algorithm. When regular nomination is used, ICE
-will converge perfectly even when both agents use different pair
-prioritization algorithms. One of the keys to such convergence is
-triggered checks, which ensure that the nominated pair is validated by
-both agents. Consequently, any future ICE enhancements MUST preserve
-triggered checks.
-</t>
-
-<t>
-ICE is also extensible to other media streams beyond RTP, and for
-transport protocols beyond UDP. Extensions to ICE for non-RTP media
-streams need to specify how many components they utilize, and assign
-component IDs to them, starting at 1 for the most important component
-ID. Specifications for new transport protocols must define how, if at
-all, various steps in the ICE processing differ from UDP.
+ICE has an extension mechanism called "ICE options".  When an agent
+supports an extension, or option, it MAY indicate support in the
+candidate exchange.  If an agent does not support a given extension,
+or option, it MUST NOT indicate support in the candidate exchange.
 </t>
 
 </section>
@@ -2583,23 +2439,16 @@ all, various steps in the ICE processing differ from UDP.
 <section anchor="sec-ta-gen" title="General">
 
 <t>
-During the ICE gathering phase (<xref target="sec-gathering"/>) and
-while ICE is performing connectivity checks (<xref target="sec-connectivity_check"/>),
-an agent triggers STUN and TURN transactions. These transactions are paced at
-a rate indicated by Ta, and the retransmission interval for each transaction
-is calculated based on the the retransmission timer for the STUN transactions
-(RTO) <xref target="RFC5389"/>.
+While an agent is gathering (<xref target="sec-gathering"/>) and
+sending connectivity checks (<xref target="sec-connectivity_check"/>),
+it triggers STUN transactions. These transactions are paced at a rate
+indicated by Ta, and the retransmission interval for each transaction
+is calculated based on the the retransmission timer for the STUN
+transactions (RTO) <xref target="RFC5389"/>.
 </t>
 
 <t>
-This section describes how the Ta and RTO values are computed during the ICE
-gathering phase and while ICE is performing connectivity checks.
-</t>
-
-<t>
-NOTE: Previously, in RFC 5245, different formulas were defined for
-computing Ta and RTO, depending on whether ICE was used for a real-time
-media stream (e.g. RTP) or not.
+This section describes how the Ta and RTO values are computed.
 </t>
 
 <t>
@@ -2623,24 +2472,23 @@ should utilize the timer values described here.
 <section anchor="sec-ta-ta" title="Ta">
 
 <t>
-ICE agents SHOULD use the default Ta value, 50 ms, but MAY use another
+Agents SHOULD use the default Ta value, 50 ms, but MAY use another
 value based on the characteristics of the associated media.
 </t>
 
 <t>
-If an ICE agent wants to use another Ta value than the default value, the
-agent MUST indicate the proposed value to its peer during the ICE
-exchange. Both agents MUST use the higher value of the proposed values.
-If an agent does not propose a value, the default value is used for that
-agent when comparing which value is higher.
+If an agent wants to use a Ta value other than the default value, it
+MUST indicate the proposed value to its peer during the candidate
+exchange. Both agents MUST use the higher value of the proposed
+values.  If an agent does not propose a value, the default value is
+used for that agent when comparing which value is higher.
 </t>
 
 <t>
-Regardless of the Ta value chosen for each ICE agent, the combination
-of all transactions from all ICE agents (if a given implementation
-runs several concurrent ICE agents) MUST NOT be sent more often than
-once every 5ms (as though there were one global Ta value for pacing
-all ICE agents).
+Regardless of the Ta value chosen by each agent, the combination of
+all transactions from all agents (if a given implementation runs
+several concurrent agents) MUST NOT be sent more often than once every
+5ms (as though there were one global Ta value for pacing all agents).
 </t>
 
 <t>
@@ -2664,13 +2512,13 @@ based on the following reasoning.
   </list>
   </t>
   <t>
-    Observe that ICE agents typically do not know the RTT for ICE
+    Observe that ICE agents typically do not know the RTT for STUN
     transactions (connectivity checks in particular), meaning that HTO
     will almost always be 500ms.
   </t>
   <t>
     Observe that a MinPacing of 5ms and HTO of 500ms gives at most 100
-    packets/HTO, which for a typical ICE check of less than 120
+    packets/HTO, which for a typical connectivity check of less than 120
     bytes means a maximum of 12000 outstanding bytes in the network,
     which is less than the maximum expressed by rule 1.
   </t>
@@ -2692,8 +2540,8 @@ using different Ta values.
 
 <t>
 
-During the ICE gathering phase, ICE agents SHOULD calculate the
-RTO value using the following formula:
+While gathering, agents SHOULD calculate the RTO value using the
+following formula:
 </t>
 
 <figure><artwork>
@@ -2708,7 +2556,7 @@ RTO value using the following formula:
 ]]></artwork></figure>
 
 <t>
-For connectivity checks, ICE agents SHOULD calculate the RTO value
+For connectivity checks, agents SHOULD calculate the RTO value
 using the following formula:
 </t>
 
@@ -2729,8 +2577,8 @@ using the following formula:
 ]]></artwork></figure>
 
 <t>
-ICE agents MAY calculate the RTO value using other mechanisms than those
-described above. ICE agents MUST NOT use a RTO value smaller than 500 ms.
+Agents MAY calculate the RTO value using other mechanisms than those
+described above. Agents MUST NOT use a RTO value smaller than 500 ms.
 </t>
 
 </section>
@@ -2770,9 +2618,8 @@ target="fig-ex-topo"/>.
 ]]></artwork></figure>
 
 
-<t> Two agents, L and R, are using ICE. Both are full-mode ICE
-implementations and use aggressive nomination when they are
-controlling. Both agents have a single IPv4 address. For agent L, it
+<t> Two agents, L and R, are using ICE. Both are full ICE
+implementations. Both agents have a single IPv4 address. For agent L, it
 is 10.0.1.1 in private address space <xref target="RFC1918"/>, and for
 agent R, 192.0.2.1 on the public Internet. Both are configured with
 the same STUN server (shown in this example for simplicity, although
@@ -2809,15 +2656,15 @@ the presence of the USE-CANDIDATE attribute.
 </t>
 
 <t>
-The call flow examples omit STUN authentication operations and RTCP,
-and focus on RTP for a single media stream between two full
+The call flow examples omit STUN authentication operations,
+and focus on a single media stream between two full
 implementations.
 </t>
 
 <figure title="Example Flow" anchor="fig:basic-ex"><artwork>
 <![CDATA[
           L             NAT           STUN             R
-          |RTP STUN alloc.              |              |
+          |STUN alloc.   |              |              |
           |(1) STUN Req  |              |              |
           |S=$L-PRIV-1   |              |              |
           |D=$STUN-PUB-1 |              |              |
@@ -2838,7 +2685,7 @@ implementations.
           |<-------------|              |              |
           |(5) L's Candidate Information|              |
           |------------------------------------------->|
-          |              |              |              | RTP STUN
+          |              |              |              | STUN
           |              |              |              | alloc.
           |              |              |(6) STUN Req  |
           |              |              |S=$R-PUB-1    |
@@ -2859,12 +2706,10 @@ implementations.
           |(10) Bind Req |              |              |
           |S=$L-PRIV-1   |              |              |
           |D=$R-PUB-1    |              |              |
-          |USE-CAND      |              |              |
           |------------->|              |              |
           |              |(11) Bind Req |              |
           |              |S=$NAT-PUB-1  |              |
           |              |D=$R-PUB-1    |              |
-          |              |USE-CAND      |              |
           |              |---------------------------->|
           |              |(12) Bind Res |              |
           |              |S=$R-PUB-1    |              |
@@ -2876,7 +2721,7 @@ implementations.
           |D=$L-PRIV-1   |              |              |
           |MA=$NAT-PUB-1 |              |              |
           |<-------------|              |              |
-          |RTP flows     |              |              |
+          |Media flows   |              |              |
           |              |(14) Bind Req |              |
           |              |S=$R-PUB-1    |              |
           |              |D=$NAT-PUB-1  |              |
@@ -2895,7 +2740,7 @@ implementations.
           |              |D=$R-PUB-1    |              |
           |              |MA=$R-PUB-1   |              |
           |              |---------------------------->|
-          |              |              |              |RTP flows
+          |              |              |              |Media flows
 
 ]]></artwork></figure>
 
@@ -2904,7 +2749,7 @@ implementations.
 server to get a server reflexive candidate (messages 1-4). Recall that
 the NAT has the address and port independent mapping property. Here,
 it creates a binding of NAT-PUB-1 for this UDP request, and this
-becomes the server reflexive candidate for RTP.  </t>
+becomes the server reflexive candidate.  </t>
 
 <t>
 Agent L sets a type preference of 126 for the host candidate and 100
@@ -2953,17 +2798,12 @@ cannot be routed from R to L.
 </t>
 
 <t> When agent L gets the R's candidates, it performs its one and only
-connectivity check (messages 10-13). It implements the aggressive
-nomination algorithm, and thus includes a USE-CANDIDATE attribute in
-this check. Since the check succeeds, agent L creates a new pair,
-whose local candidate is from the mapped address in the Binding
-response (NAT-PUB-1 from message 13) and whose remote candidate is the
-destination of the request (R-PUB-1 from message 10). This is added to
-the valid list. In addition, it is marked as selected since the
-Binding request contained the USE-CANDIDATE attribute. Since there is
-a selected candidate pair in the valid list for the one component of this
-media stream, ICE processing for this stream moves into the Completed
-state. Agent L can now send media if it so chooses.
+connectivity check (messages 10-13). Since the check succeeds, agent L
+creates a new pair, whose local candidate is from the mapped address
+in the Binding response (NAT-PUB-1 from message 13) and whose remote
+candidate is the destination of the request (R-PUB-1 from message
+10). This is added to the valid list. Agent L can now send media if it
+so chooses.
 </t>
 
 <t>
@@ -2975,10 +2815,7 @@ succeed. Consequently, agent R constructs a new candidate pair using
 the mapped address from the response as the local candidate (R-PUB-1)
 and the destination of the request (NAT-PUB-1) as the remote
 candidate. This pair is added to the valid list for that media
-stream. Since the check was generated in the reverse direction of a
-check that contained the USE-CANDIDATE attribute, the candidate pair
-is marked as selected. Consequently, processing for this stream moves
-into the Completed state, and agent R can also send media.
+stream. Agent R can also send media.
 </t>
 
 </section>
@@ -3284,7 +3121,7 @@ sent.
 <section anchor="sec-ice-newatts" title="New Attributes">
 
 <t>
-This specification defines four new attributes, PRIORITY,
+This specification defines four new STUN attributes, PRIORITY,
 USE-CANDIDATE, ICE-CONTROLLED, and ICE-CONTROLLING.
 </t>
 
@@ -3309,7 +3146,7 @@ role. The content of the attribute is a 64-bit unsigned integer in
 network byte order, which contains a random number. The number is used
 for solving role conflicts, when it is referred to as the tie-breaker
 value. An ICE agent MUST use the same number for all Binding requests,
-for all streams, within an ICE session. The ICE agent MAY change
+for all streams, within an ICE session. The ICE agent MUST NOT change
 the number when an ICE restart occurs.
 </t>
 
@@ -3320,7 +3157,7 @@ role. The content of the attribute is a 64-bit unsigned integer in
 network byte order, which contains a random number. The number is used
 for solving role conflicts, when it is referred to as the tie-breaker
 value. An ICE agent MUST use the same number for all Binding requests,
-for all streams, within an ICE session. The ICE agent MAY change
+for all streams, within an ICE session. The ICE agent MUST NOT change
 the number when an ICE restart occurs.
 </t>
 
@@ -3401,7 +3238,7 @@ speaking).
 TURN traffic is more substantial. The TURN server will see traffic
 volume equal to the STUN volume (indeed, if TURN servers are deployed,
 there is no need for a separate STUN server), in addition to the
-traffic for the actual media traffic. The amount of calls requiring
+traffic for the actual media. The amount of calls requiring
 TURN for media relay is highly dependent on network topologies, and
 can and will vary over time. In a network with 100% behave-compliant
 NAT, it is exactly zero. At time of writing, large-scale consumer
@@ -3444,14 +3281,16 @@ ICE network friendly and easier to deploy.
 <section title="Keepalives">
 
 <t>
-STUN keepalives (in the form of STUN Binding Indications) are sent in
+Keepalives are sent in
 the middle of a media session. However, they are sent only in the
-absence of actual media traffic. In deployments that are not utilizing
-Voice Activity Detection (VAD), the keepalives are never used and
-there is no increase in bandwidth usage. When VAD is being used,
-keepalives will be sent during silence periods. This involves a single
-packet every 15-20 seconds, far less than the packet every 20-30 ms
-that is sent when there is voice. Therefore, keepalives don't have any
+absence of actual media traffic. 
+In scenarios where media is being sent continuously,
+keepalives are never used and
+there is no increase in bandwidth usage. When media is not being sent continuously,
+keepalives will be sent during periods when no media is being sent. 
+This involves a single
+packet every 15-20 seconds, which compared to most media flows is minor. 
+Therefore, keepalives don't have any
 real impact on capacity planning.
 </t>
 
@@ -3485,22 +3324,22 @@ they know how ICE is performing?
 </t>
 
 <t>
-ICE has built-in features to help deal with these problems. SIP
-servers on the signaling path, typically deployed in the data centers
+ICE has built-in features to help deal with these problems. Signaling
+servers, typically deployed in the data centers
 of the network operator, will see the contents of the candidate
 exchanges that convey the ICE parameters. These parameters include the
 type of each candidate (host, server reflexive, or relayed), along
 with their related addresses. Once ICE processing has completed, an
 updated candidate exchange takes place, signaling the selected
-address (and its type). This updated re-INVITE is performed exactly
+address (and its type). This updated signaling is performed exactly
 for the purposes of educating network equipment (such as a diagnostic
-tool attached to a SIP server) about the results of ICE processing.
+tool attached to a signaling) about the results of ICE processing.
 </t>
 
 <t>
-As a consequence, through the logs generated by the SIP server, a
+As a consequence, through the logs generated by a signaling server, a
 network operator can observe what types of candidates are being used
-for each call, and what address was selected by ICE. This is the
+for each call, and what address were selected by ICE. This is the
 primary information that helps evaluate how ICE is performing.
 </t>
 
@@ -3626,7 +3465,7 @@ considerations. This section meets those requirements.
 <section title="Problem Definition">
 
 <t>
->From RFC 3424, any UNSAF proposal must provide:
+From RFC 3424, any UNSAF proposal must provide:
 </t>
 
 <t><list style="hanging">
@@ -3661,7 +3500,7 @@ reachable by another peer with which it wishes to communicate.
 <section title="Exit Strategy">
 
 <t>
->From RFC 3424, any UNSAF proposal must provide:
+From RFC 3424, any UNSAF proposal must provide:
 </t>
 
 <t><list style="hanging"><t>
@@ -3698,7 +3537,7 @@ address to use when communicating with a peer.
 <section title="Brittleness Introduced by ICE">
 
 <t>
->From RFC 3424, any UNSAF proposal must provide:
+From RFC 3424, any UNSAF proposal must provide:
 </t>
 
 <t><list style="hanging"><t>

--- a/draft-ietf-ice-rfc5245bis.xml
+++ b/draft-ietf-ice-rfc5245bis.xml
@@ -750,14 +750,15 @@ The order is determined by each ICE usage.
 </t>
 
 
-<t hangText="Full Implementation:"> 
-An ICE implementation that performs the complete
-set of functionality defined by this specification.
+<t hangText="Full Implementation:"> An ICE implementation that
+performs the complete set of functionality defined by this
+specification.
 </t>
 
 <t hangText="Lite Implementation:"> An ICE implementation that
 performs a limited set of functionality defined by this specification.
-In particular, lite implementations do not send connectivity checks.
+In particular, it only uses host candidates and does not send
+connectivity checks.
 </t>
 
 <t hangText="Controlling Agent:"> The ICE agent that nominates a
@@ -1138,19 +1139,11 @@ to use a value other than default, it MUST include this in the exchange. </t>
 
 <t hangText="Extensions:">Extensions that the agent supports.</t>
 
-<t hangText="Candidates: "> For each candidiate, the following information:
-<list style="hanging">
-   <t hangText="Address:"> The IP address and transport protocol
-   port. </t>
-   <t hangText="Transport protocol:"> As defined. </t>
-   <t hangText="Foundation:"> As defined.</t>
-   <t hangText="Component ID:"> As defined.</t>
-   <t hangText="Priority:"> As defined. </t>
-   <t hangText="Type:"> As defined. </t>
-   <t hangText="Related Address:"> As defined. MAY be omitted or
-   set to invalid values if the agent does not want to reveal them.
-   </t>
-</list></t>
+<t hangText="Candidates: "> For each candidiate, the type, IP address,
+transport protocol, transport protocol port, foundation, component ID,
+priority, and related address.  The related address MAY be omitted or
+set to invalid values if the agent does not want to reveal them.
+</t>
 
 </list></t>
 
@@ -1437,8 +1430,8 @@ For each foundation, the agent sets the state of exactly one candidate
 pair to the Waiting state (unfreezing it).  The candidate pair to
 unfreeze is choosen by finding the first candidate pair (ordered by
 lowest component ID and then highest priority if component IDs are
-equal) in the first check list in the check list set that has that
-foundation.
+equal) in the first check list (ordered by the check list set) that
+has that foundation.
 </t>
 
 </list></t>
@@ -1520,7 +1513,7 @@ foundation in the check list set has been placed in the Waiting state.
 
 <section title="ICE State">
 <t>
-The ICE agents has a state determined by the state of the check
+The ICE agent has a state determined by the state of the check
 lists. The state is Completed if all check lists are Completed, Failed
 if any check list is Failed, and Running otherwise.
 </t>
@@ -1534,29 +1527,28 @@ agent chooses a candidate pair and sends the first check by by sending
 a STUN request from the base of the local candiditate to the remote
 candidate following the procedures in <xref
 target="sec-connectivity_check"/>.  Then every time Ta fires, it
-chooses a candidate pair and sends a check.  After sending these
-checks, the agent sets the candidate pair's state to In-Progress.
+chooses a candidate pair and sends a check.  After sending each check,
+the agent sets the candidate pair's state to In-Progress.
 </t>
 
 <t>The agent chooses a candidate pair by first choosing a check list
 and second choosing a candidate pair within that check list.  If the
 process of choosing a candidate pair within a check list results in no
 candidate pair, the agent follows the same procedure again to choose a
-different heck list until a candidate pair is chosen.
+different check list until a candidate pair is chosen.
 </t>
 
 <t>
 The first time the agent chooses a check list, it chooses the first
-check list in the check list set that is in the Running state.
-Subsequent times, the agent chooses the next check list in the check
-list set that is in the Running state.  If there is no such check list
-in the Running state, the agent chooses the first such check list in
-the check list set again, thus cycling through all the check lists in
-the Running state repeatedly.
+check list (ordered by the check list set) that is in the Running
+state.  Subsequent times, the agent chooses the next check list that
+is in the Running state.  If there is no such check list in the
+Running state, the agent chooses the first check list in the Running
+state again, thus cycling through all the check lists in the Running
+state repeatedly.
 </t>
 
-<t>
-The agent chooses a candidate pair within a check list by first
+<t>The agent chooses a candidate pair within a check list by first
 examining a FIFO queue of candidate pairs called the TRIGGERED CHECK
 QUEUE. If the triggered check queue is not empty, the agent removes
 the first pair from the queue and chooses that pair.  If the triggered
@@ -1578,8 +1570,7 @@ for the check list, and the agent may choose another check list.
 </t>
 
 <t>An agent MAY terminate connectivity checks for specific checks
-lists at any time. However, only the controlling agent may conclude
-ICE (<xref target="sec-conclude"/>).
+lists at any time.
 </t>
 
 </section>
@@ -1590,8 +1581,8 @@ ICE (<xref target="sec-conclude"/>).
 
  <t>
  Because lite agents do not send connectivity checks, they not perform
- the steps necessary for candidate pair and check lists states and
- choosing check lists and candidate pairs.
+ the steps necessary to to choose a candidate pair for sending a
+ connectivity check.
  </t>
 
 </section>
@@ -1620,14 +1611,14 @@ new attributes.
 
 <section title="PRIORITY">
 <t>The priority attribute MUST be included in a Binding request and be
-set to value computed by the algorithm in <xref
-target="sec-prioritizing"/> for the local candidate, but with a
-candidate type preference for peer reflexive candidates.
+set to the value computed by the algorithm in <xref
+target="sec-prioritizing"/> for the local candidate, but with the
+candidate type preference of peer reflexive candidates.
 </t>
 </section>
 
 <section title="USE-CANDIDATE">
-<t>The controlling ICE agent includes the USE-CANDIDATE attribute in
+<t>The controlling ICE agent MUST include the USE-CANDIDATE attribute in
 order to nominate a candidate pair <xref target="sec-choose-favor"/>.
 The controlled ICE agent MUST NOT include the USE-CANDIDATE attribute
 in a Binding request.

--- a/draft-ietf-ice-rfc5245bis.xml
+++ b/draft-ietf-ice-rfc5245bis.xml
@@ -81,11 +81,11 @@ create a media flow directly between participants, so that there is
 no application layer intermediary between them.  This is done to
 reduce media latency, decrease packet loss, and reduce the
 operational costs of deploying the application.  However, this is
-difficult to accomplish through NAT.  A full treatment of the reasons
+difficult to accomplish through NATs.  A full treatment of the reasons
 for this is beyond the scope of this specification.  </t>
 
 <t> Numerous solutions have been defined for allowing these protocols
-to operate through NAT. These include Application Layer Gateways
+to operate through NATs. These include Application Layer Gateways
 (ALGs), the <xref target="RFC3303"> Middlebox Control Protocol</xref>,
 the original <xref target="RFC3489">Simple Traversal of UDP Through
 NAT (STUN)</xref> specification, and <xref target="RFC3102">Realm
@@ -232,7 +232,7 @@ Internet (I2). A candidate from I1 will be directly reachable when
 communicating with a peer on the same private net 10 network, while a
 candidate from I2 will be directly reachable when communicating with a
 peer on the public Internet. Rather than trying to guess which IP
-address will work, the initiating sends both the candidates to its
+address will work, the initiating agent sends both the candidates to its
 peer.
 </t>
 
@@ -288,15 +288,9 @@ X1':x1', mapping this server reflexive candidate to the host candidate
 X:x. Outgoing packets sent from the host candidate will be translated
 by the NAT to the server reflexive candidate.  Incoming packets sent
 to the server reflexive candidate will be translated by the NAT to the
-host candidate and forwarded to the agent. We call the host candidate
-associated with a given server reflexive candidate the BASE.
+host candidate and forwarded to the agent. The host candidate
+associated with a given server reflexive candidate is the BASE.
 </t>
-
-<t><list style="empty">
-<t>Note: "Base" refers to the address an agent sends from for a particular
-candidate. Thus, as a degenerate case host candidates also have a base,
-but it's the same as the host candidate.
-</t></list></t>
 
 <t>
 When there are multiple NATs between the agent and the TURN server,
@@ -372,16 +366,15 @@ STUN response ->            /  check
 It is important to note that the STUN requests are sent to and from
 the exact same IP addresses and ports that will be used for media
 (e.g., RTP and RTCP). Consequently, agents demultiplex STUN and
-RTP/RTCP using contents of the packets, rather than the port on which
-they are received. Fortunately, this demultiplexing is easy to do,
-especially for RTP and RTCP.
+media using contents of the packets, rather than the port on which
+they are received.
 </t>
 
 <t>
 Because a STUN Binding request is used for the connectivity check, the
 STUN Binding response will contain the agent's translated transport
 address on the public side of any NATs between the agent and its
-peer. If this transport address is different from other candidates the
+peer. If this transport address is different from that of other candidates the
 agent already learned, it represents a new candidate, called a PEER
 REFLEXIVE CANDIDATE, which then gets tested by ICE just the same as
 any other candidate.
@@ -405,7 +398,7 @@ send (and receive) messages end-to-end in both directions.
 <section title="Sorting Candidates">
 
 <t>
-Because the algorithm above searches all candidate pairs, if a working
+Because the algorithm above searches all candidate pairs, if a valid
 pair exists it will eventually find it no matter what order the
 candidates are tried in. In order to produce faster (and better)
 results, the candidates are sorted in a specified order. The resulting
@@ -452,14 +445,11 @@ discretion about how to tune their algorithms.
 wish to establish a media session with one COMPONENT (a piece of a
 media stream requiring a single transport address; a media stream may
 require multiple components, each of which has to work for the media
-stream as a whole to be work). Sometimes (e.g., with RTP and RTCP in
-separate components), the agents actually need to establish
-connectivity for more than one flow. </t>
+stream as a whole to be work).</t>
 
 <t>
 The network properties are likely to be very similar for each
-component (especially because RTP and RTCP are sent and received
-from the same IP address). It is usually possible to leverage
+component. It is usually possible to leverage
 information from one media component in order to determine the best
 candidates for another. ICE does this with a mechanism called "frozen
 candidates".
@@ -472,10 +462,10 @@ FOUNDATION. Two candidates have the same foundation when they are
 candidate and STUN/TURN server using the same protocol. Otherwise,
 their foundation is different. A candidate pair has a foundation too,
 which is just the concatenation of the foundations of its two
-candidates. Initially, only the candidate pairs with unique
-foundations are tested.  The other candidate pairs are marked
-"frozen". When the connectivity checks for a candidate pair succeed,
-the other candidate pairs with the same foundation are unfrozen. This
+candidates. Initially, only candidate pairs with unique
+foundations are tested and other candidate pairs are marked
+"frozen". When connectivity checks succeed,
+other candidate pairs with the same foundation are unfrozen. This
 avoids repeated checking of components that are superficially more
 attractive but in fact are likely to fail.
 </t>
@@ -539,11 +529,9 @@ for media amongst the ones that are valid.
 </t>
 
 <t>
-When nominating, the controlling agent lets the checks continue
-until at least one valid candidate pair for each media stream is
-found. Then, it picks amongst those that are valid, and sends a second
-STUN request on its NOMINATED candidate pair, but this time with a
-flag set to tell the peer that this pair has been nominated for use.
+When nominating, the controlling agent selects a candidate pair and
+sends a STUN request on the selected pair with a flag set to indicate
+to the controlled peer that it has nominated the selected pair.
 This is shown in <xref target="fig-regular-select"/>.
 </t>
 
@@ -564,16 +552,13 @@ STUN request + flag ->      \  L's
 ]]></artwork></figure>
 
 <t>
-Once the STUN transaction with the flag completes, both sides cancel
-any future checks for that media stream. ICE will now send media using
-this pair. The pair an ICE agent is using for media is called the
-SELECTED PAIR.
+Once the STUN transaction with the flag completes, the controlled
+agent will select the nominated candidate pair and send media using it.
 </t>
 
 <t>
-Once ICE is concluded, it can be restarted at any time for one or all
-of the media streams by either agent. This is done by sending an updated
-candidate information indicating a restart.
+ICE can be restarted according to the mechanism defined by the using
+protocol.
 </t>
 
 </section>
@@ -581,14 +566,13 @@ candidate information indicating a restart.
 <section title="Lite Implementations">
 
 <t>
-In order for ICE to be used in a call, both agents need to support it.
+In order for ICE to work, both agents need to support it.
 However, certain agents will always be connected to the public
 Internet and have a public IP address at which it can receive packets
 from any correspondent. To make it easier for these devices to support
 ICE, ICE defines a special type of implementation called LITE (in
-contrast to the normal FULL implementation). A lite implementation
-doesn't gather candidates; it includes only host candidates for any
-media stream.  Lite agents do not generate connectivity checks or run
+contrast to the normal FULL implementation). 
+Lite agents do not generate connectivity checks or run
 the state machines, though they need to be able to respond to
 connectivity checks. When a lite implementation connects with a full
 implementation, the full agent takes the role of the controlling
@@ -613,7 +597,7 @@ implementation is preferable if achievable.
 <section title="Usages of ICE">
 
 <t>This document specifies generic use of ICE with protocols that
-provide means to exchange candidate information between the ICE Peers.
+provide means to exchange candidate information between the ICE agents.
 The specific details of (i.e how to encode candidate information and
 the actual candidate exchange process) for different protocols using
 ICE are described in separate usage documents. One possible way the
@@ -645,20 +629,17 @@ This specification makes use of the following additional terminology:
 <t><list style="hanging">
 
 <t hangText="ICE Agent:">
-An agent is the protocol implementation involved in the
-ICE candidate exchange.  There are two agents involved in a typical
-candidate exchange. </t>
+An ICE agent is the protocol implementation involved in the
+ICE candidate exchange.</t>
 
 <t hangText= "Initiating Peer, Initiating Agent, Initiator:">
-An initiating agent is the protocol implementation involved in the ICE
-candidate exchange that initiates the ICE candidate exchange
+The initiating agent is an ICE agent that initiates the ICE candidate exchange
 process. </t>
 
 <t hangText="Responding Peer, Responding Agent, Responder:">
-A receiving agent is the protocol implementation involved in the ICE
-candidate exchange that receives
+The receiving agent is ICE agent that receives
 and responds to the candidate exchange process initiated by the
-Initiator. </t>
+initiating agent. </t>
 
 <t hangText="ICE Candidate Exchange, Candidate Exchange:">
 The process where the ICE agents exchange information (e.g.,
@@ -669,9 +650,7 @@ information. </t>
 
 <t hangText="Peer:">
 From the perspective of one of the agents in a session, its peer is
-the other agent. Specifically, from the perspective of the initiating
-agent, the peer is the responding agent.  From the perspective of the
-responding agent, the peer is the initiating agent. </t>
+the other agent.</t>
 
 <t hangText="Transport Address:"> The combination of an IP address and
 transport protocol (such as UDP or TCP) port.</t>
@@ -687,47 +666,36 @@ the path created and tested with ICE. </t>
 <t hangText="Candidate, Candidate Information:"> A transport address
 that is a potential point of contact for receipt of media. Candidates
 also have properties -- their type (server reflexive, relayed, or
-host), priority,foundation, and base.
+host), priority, foundation, and base.
 </t>
 
 <t hangText="Component:"> A component is a piece of a media stream
 requiring a single transport address; a media stream may require
 multiple components, each of which has to work for the media stream as
-a whole to work. For media streams based on RTP, unless RTP and RTCP
-are multiplexed in the same port, there are two components per media
-stream -- one for RTP, and one for RTCP. </t>
+a whole to work.</t>
 
 <t hangText="Host Candidate:"> A candidate obtained by binding to a
-specific port from an IP address on the host. This includes IP
-addresses on physical interfaces and logical ones, such as ones
-obtained through Virtual Private Networks (VPNs) and Realm Specific IP
-(RSIP) <xref target="RFC3102"/> (which lives at the operating system
-level).
+port.
 </t>
 
 <t hangText="Server Reflexive Candidate:"> A candidate whose IP
 address and port are a binding allocated by a NAT for an agent when it
-sent a packet through the NAT to a server. Server reflexive candidates
-can be learned by STUN servers using the Binding request, or TURN
-servers, which provides both a relayed and server reflexive candidate.
+sent a packet through the NAT to a server, such as a STUN server.
 </t>
 
 <t hangText="Peer Reflexive Candidate:"> A candidate whose IP
 address and port are a binding allocated by a NAT for an agent when it
-sent a STUN Binding request through the NAT to its peer.
+sent a packet through the NAT to its peer.
 </t>
 
-<t hangText="Relayed Candidate:"> A candidate obtained by sending a
-TURN Allocate request from a host candidate to a TURN server. The
-relayed candidate is resident on the TURN server, and the TURN server
-relays packets back towards the agent.
+<t hangText="Relayed Candidate:"> A candidate obtained from a relay
+server, such as a TURN server, which relays packets.
 </t>
 
 <t hangText="Base:"> The transport address that an agent sends from
-for a particular candidate. For host-, server reflexive- and peer reflexive
+for a particular candidate. For host, server reflexive and peer reflexive
 candidates the base is the same as the host candidate. For relayed
-candidates the base is the same as the relayed candidate (i.e., the
-transport address used by the TURN server to send from).
+candidates the base is the same as the relayed candidate.
 </t>
 
 <t hangText="Foundation:"> An arbitrary string that is the same for
@@ -735,11 +703,10 @@ two candidates that have the same type, base IP address, protocol
 (UDP, TCP, etc.), and STUN or TURN server.  If any of these are
 different, then the foundation will be different. Two candidate pairs
 with the same foundation pairs are likely to have similar network
-characteristics.  Foundations are used in the frozen algorithm.
+characteristics.  Foundations are used to freeze and unfreeze candidates.
 </t>
 
-<t hangText="Local Candidate:">A candidate that an agent has obtained
-and shared with the peer.
+<t hangText="Local Candidate:">A candidate that an agent has obtained and may send it its peer.
 </t>
 
 <t hangText="Remote Candidate:">A candidate that an agent received
@@ -748,19 +715,19 @@ from its peer.
 
 <t hangText="Default Destination/Candidate:"> The default destination
 for a component of a media stream is the transport address that would
-be used by an agent that is not ICE aware.  A default candidate for a
+be used by an agent that is not ICE-aware.  A default candidate for a
 component is one whose transport address matches the default
 destination for that component.
 </t>
 
-<t hangText="Candidate Pair:"> A pairing containing a local candidate
+<t hangText="Candidate Pair:"> The pair of a local candidate
 and a remote candidate.
 </t>
 
 <t hangText="Check, Connectivity Check, STUN Check:"> A STUN Binding
-request transaction for the purposes of verifying connectivity. A
-check is sent from the local candidate to the remote candidate of a
-candidate pair.
+request for the purposes of verifying connectivity. A
+check is sent from the base of the local candidate 
+to the remote candidate of a candidate pair.
 </t>
 
 <t hangText="Check List:"> An ordered set of candidate pairs that an
@@ -776,7 +743,7 @@ it to send a check.
 consequence of the receipt of a connectivity check from the peer.
 </t>
 
-<t hangText="VALID LIST:"> An ordered set of candidate pairs for a
+<t hangText="Valid list:"> An ordered set of candidate pairs for a
 media stream that have been validated by a successful STUN
 transaction.
 </t>
@@ -784,31 +751,28 @@ transaction.
 <t hangText="Check List Set:"> An ordered list of CHECK LISTs.
 </t>
 
-<t hangText="Full:"> An ICE implementation that performs the complete
+
+<t hangText="Full Implementation:"> 
+An ICE implementation that performs the complete
 set of functionality defined by this specification.
 </t>
 
-<t hangText="Lite:"> An ICE implementation that omits certain
-functions, implementing only as much as is necessary for a peer
-implementation that is full to gain the benefits of ICE. Lite
-implementations do not maintain any of the state machines and do not
-generate connectivity checks.
+<t hangText="Lite Implementation:"> An ICE implementation that
+performs a limited set of functionality defined by this specification.
+In particular, lite implementations do not send connectivity checks.
 </t>
 
-<t hangText="Controlling Agent:"> The ICE agent that is responsible
-for selecting the final choice of candidate pairs and signaling them
-through STUN. In any session, one agent is always controlling. The
-other is the controlled agent.
+<t hangText="Controlling Agent:"> The ICE agent that nominates a
+candidate pair.
 </t>
 
-<t hangText="Controlled Agent:"> An ICE agent that waits for the
-controlling agent to select the final choice of candidate pairs.
+<t hangText="Controlled Agent:"> The ICE agent that does not nominate a
+candidate pair.
 </t>
 
-<t hangText="Nomination, Regular Nomination:"> The process of picking a valid
-candidate pair for media traffic by validating the pair with one
-STUN request, and then picking it by sending a second STUN request
-with a flag indicating its nomination.
+<t hangText="Nomination, Regular Nomination:"> The process of the
+controlling agent indicating to the controlled agent which candidate
+pair the controlled agent should use to send media.
 </t>
 
 <t hangText="Nominated:"> If a valid candidate pair has its nominated
@@ -816,16 +780,14 @@ flag set, it means that it may be selected by ICE for sending and
 receiving media.
 </t>
 
-<t hangText="Selected Pair, Selected Candidate:"> The candidate pair
-selected by ICE for sending and receiving media is called the selected
-pair, and each of its candidates is called the selected candidate.
-Before a  pair has been selected, any valid candidate pair
-can be used for sending and receiving media (only one candidate pair
-at any given time).
+<t hangText="Selected Pair, Selected Candidate Pair:"> The candidate pair
+selected by an ICE agent for sending media is called the selected
+pair.  Before a pair has been selected, any valid candidate pair
+can be used for sending and receiving media.
 </t>
 
 <t hangText="Using Protocol, ICE Usage:"> The protocol that uses ICE
-for NAT traversal. A usage specification defines the protocol specific
+for NAT traversal. A usage specification defines the protocol-specific
 details on how the procedures defined here are applied to that
 protocol. </t>
 
@@ -839,15 +801,14 @@ protocol. </t>
 <t>
 As part of ICE processing, both the initiating and responding agents
 exchange encoded candidate information as defined by the Usage
-Protocol (ICE Usage). Specifics of encoding mechanism and the
+Protocol (ICE Usage). Specifics of the encoding mechanism and the
 semantics of candidate information exchange is out of scope of this
 specification.
 </t>
 
 <t>
-However at a higher level, the below diagram captures ICE processing
-sequence in the agents (initiator and responder) for exchange of
-their respective candidate(s) information.
+However at a higher level, the diagram below shows the how ICE agents
+exchange of their respective candidate(s) information.
 </t>
 
 <figure title="Candidate Gathering and Exchange Sequence"
@@ -879,9 +840,9 @@ candidates   |                               |
 ]]></artwork></figure>
 <t>
 As shown, the agents involved in the candidate exchange perform (1)
-candidate gathering, (2) candidate prioritization, (3) eliminating
-redundant candidates, (4) (possibly) choose default candidates, and
-then (5) formulate and send the candidates to the Peer ICE agent. All
+candidate gathering, (2) candidate prioritization, (3) redundant 
+candidate elimination, (4) (possibly) default candidate selection, and
+(5) sending of the candidates to the peer. All
 but the last of these five steps differ for full and lite
 implementations.
 </t>
@@ -894,40 +855,20 @@ implementations.
 <section anchor="sec-gathering" title="Gathering Candidates">
 
 <t>
-An agent gathers candidates when it believes that communication is
-imminent.  An initiating agent can do this based on a user interface
-cue, or based on an explicit request to initiate a session.  Every
-candidate is a transport address.  It also has a type and a base.
-Four types are defined and gathered by this specification -- host
-candidates, server reflexive candidates, peer reflexive candidates,
-and relayed candidates.  The server reflexive candidates are gathered
-using STUN or TURN, and relayed candidates are obtained through TURN.
-Peer reflexive candidates are obtained in later phases of ICE, as a
-consequence of connectivity checks.
-</t>
-
-<t>
-The process for gathering candidates at the responding agent is
-identical to the process for the initiating agent. It is RECOMMENDED
-that the responding agent begins this process immediately on receipt
-of the candidate information, prior to alerting the user. Such
-gathering MAY begin when an agent starts.
+Four types of candidates are gathered by the ICE agent according to
+this specification: host, server reflexive, peer reflexive, and relayed.
 </t>
 
 <section title="Host Candidates">
 
-<t> The first step is to gather host candidates. Host candidates are
-obtained by binding to ports (typically ephemeral) on a IP address
+<t> Host candidates are obtained by binding to ports on a IP address
 attached to an interface (physical or virtual, including VPN
 interfaces) on the host.
 </t>
 
-<t>For each UDP media stream the agent wishes to use, the agent SHOULD
-obtain a candidate for each component of the media stream on each IP
-address that the host has, with the exceptions listed below. The agent
-obtains each candidate by binding to a UDP port on the specific IP
-address. A host candidate (and indeed every candidate) is always
-associated with a specific component for which it is a candidate. </t>
+<t>For each component of each media stream the agent wishes to use,
+the agent SHOULD gather a candidate on each IP address that the host
+has, with the exceptions listed below.</t>
 
 <t> Each component has an ID assigned to it, called the component ID.
 For RTP-based media streams, unless both RTP and RTCP are multiplexed
@@ -942,27 +883,9 @@ multiplexing), or unless the agent only supports RTP/RTCP
 multiplexing, the agent MUST obtain a separate candidate for RTCP. If
 an agent has obtained a candidate for RTCP, and ends up using RTP/RTCP
 multiplexing, the agent does not need to perform connectivity checks
-on the RTCP candidate.</t>
-
-<t>If an agent is using separate candidates for RTP and RTCP, it will
-end up with 2*K host candidates if an agent has K IP addresses.</t>
-
-<t>Note that the responding agent, when obtaining its candidates, will
-typically know if the other agent supports RTP/RTCP multiplexing, in
-which case it will not need to obtain a separate candidate for
-RTCP. However, absence of a component ID 2 as such does not imply use
-of RTCP/RTP multiplexing, as it could also mean that RTCP is not
-used. </t>
-
-<t> For other than RTP-based streams, use of multiple components is
-discouraged since using them increases the complexity of ICE
-processing. If multiple components are needed, the component IDs
-SHOULD start with 1 and increase by 1 for each component.
-</t>
-
-<t>
-The base for each host candidate is set to the candidate itself.
-</t>
+on the RTCP candidate.  Absence of a component ID 2 as such does not
+imply use of RTCP/RTP multiplexing, as it could also mean that RTCP is
+not used. </t>
 
 <t> The host candidates are gathered from all IP addresses with the
 following exceptions:
@@ -3139,7 +3062,7 @@ ICE processing otherwise.
 
 <t>
 An agent MUST begin the keepalive processing once ICE has selected
-candidates for usage with media, or media begins to flow, whichever
+candidate pairs for usage with media, or media begins to flow, whichever
 happens first. Keepalives end once the session terminates or the media
 stream is removed.
 </t>
@@ -3713,7 +3636,7 @@ response (NAT-PUB-1 from message 13) and whose remote candidate is the
 destination of the request (R-PUB-1 from message 10). This is added to
 the VALID LIST. In addition, it is marked as selected since the
 Binding request contained the USE-CANDIDATE attribute. Since there is
-a selected candidate in the VALID LIST for the one component of this
+a selected candidate pair in the VALID LIST for the one component of this
 media stream, ICE processing for this stream moves into the Completed
 state. Agent L can now send media if it so chooses.
 </t>

--- a/draft-ietf-ice-rfc5245bis.xml
+++ b/draft-ietf-ice-rfc5245bis.xml
@@ -524,8 +524,7 @@ better than one with higher priority.
 <t>
 Consequently, ICE assigns one of the agents in the role of the
 CONTROLLING AGENT, and the other of the CONTROLLED AGENT. The
-controlling agent gets to nominate which candidate pairs will get used
-for media amongst the ones that are valid.
+controlling agent nominates a candidate pair to be used for media.
 </t>
 
 <t>
@@ -698,12 +697,8 @@ candidates the base is the same as the host candidate. For relayed
 candidates the base is the same as the relayed candidate.
 </t>
 
-<t hangText="Foundation:"> An arbitrary string that is the same for
-two candidates that have the same type, base IP address, protocol
-(UDP, TCP, etc.), and STUN or TURN server.  If any of these are
-different, then the foundation will be different. Two candidate pairs
-with the same foundation pairs are likely to have similar network
-characteristics.  Foundations are used to freeze and unfreeze candidates.
+<t hangText="Foundation:"> An arbitrary string used to group similar
+candidates and control candidates freezing.
 </t>
 
 <t hangText="Local Candidate:">A candidate that an agent has obtained and may send it its peer.
@@ -901,7 +896,7 @@ following exceptions:
     candidates. </t>
 
     <t> IPv4-mapped IPv6 addresses SHOULD NOT be included in the
-    offered candidates unless the application using ICE does not
+    address candidates unless the application using ICE does not
     support IPv4 (i.e., is an IPv6-only application <xref
     target="RFC4038"/>). </t>
 
@@ -922,85 +917,41 @@ following exceptions:
 <section title="Server Reflexive and Relayed Candidates">
 
 <t>
-Agents SHOULD obtain relayed candidates and SHOULD obtain server
-reflexive candidates. These requirements are at SHOULD strength to
-allow for provider variation. Use of STUN and TURN servers may be
-unnecessary in closed networks where agents are never connected to the
-public Internet or to endpoints outside of the closed network. In such
-cases, a full implementation would be used for agents that are
-dual-stack or multihomed, to select a host candidate. Use of TURN
-servers is expensive, and when ICE is being used, they will only be
-utilized when both endpoints are behind NATs that perform address and
-port dependent mapping. Consequently, some deployments might consider
-this use case to be marginal, and elect not to use TURN servers. If an
-agent does not gather server reflexive or relayed candidates, it is
-RECOMMENDED that the functionality be implemented and just disabled
-through configuration, so that it can be re-enabled through
-configuration if conditions change in the future.
-</t>
-
-<t>
-If an agent is gathering both relayed and server reflexive candidates,
-it uses a TURN server. If it is gathering just server reflexive
-candidates, it uses a STUN server.
-</t>
-
-<t>
-The agent next pairs each host candidate with the STUN or TURN server
-with which it is configured or has discovered by some means. If a STUN
-or TURN server is configured, it is RECOMMENDED that a domain name be
-configured, and the DNS procedures in <xref target="RFC5389"/> (using
-SRV records with the "stun" service) be used to discover the STUN
-server, and the DNS procedures in <xref target="RFC5766"/> (using SRV
-records with the "turn" service) be used to discover the TURN server.
+An agent SHOULD gather server reflexive and relayed candidates.
 </t>
 
 <t>This specification only considers usage of a single STUN or TURN
 server. When there are multiple choices for that single STUN or TURN
-server (when, for example, they are learned through DNS records and
-multiple results are returned), an agent SHOULD use a single STUN or
-TURN server (based on its IP address) for all candidates for a
-particular session. This improves the performance of ICE. The result
-is a set of pairs of host candidates with STUN or TURN servers. The
-agent then chooses one pair, and sends a Binding or Allocate request
-to the server from that host candidate. Binding requests to a STUN
-server are not authenticated, and any ALTERNATE-SERVER attribute in a
-response is ignored. Agents MUST support the backwards compatibility
-mode for the Binding request defined in <xref
-target="RFC5389"/>. Allocate requests SHOULD be authenticated using a
-long-term credential obtained by the client through some other means.
+server, an agent SHOULD use a single STUN or
+TURN server for all candidates for a
+particular session to improve the performance of ICE.
 </t>
 
 <t>
-Every Ta milliseconds thereafter, the agent can generate another new
-STUN or TURN transaction. This transaction can either be a retry of a
-previous transaction that failed with a recoverable error (such as
-authentication failure), or a transaction for a new host candidate and
-STUN or TURN server pair. The agent SHOULD NOT generate transactions
+An agent MUST support the backwards compatibility mode for the Binding
+request defined in <xref target="RFC5389"/> and MUST ignore any
+ALTERNATE-SERVER attribute in a STUN Binding response.
+</t>
+
+<t>
+The agent SHOULD NOT generate transactions
 more frequently than one every Ta milliseconds. See <xref
 target="sec-ta"/> for guidance on how to set Ta and the STUN
 retransmit timer, RTO.
 </t>
 
-<t>The agent will receive a Binding or Allocate response. A successful
-Allocate response will provide the agent with a server reflexive
-candidate (obtained from the mapped address) and a relayed candidate
-in the XOR-RELAYED-ADDRESS attribute. If the Allocate request is
-rejected because the server lacks resources to fulfill it, the agent
-SHOULD instead send a Binding request to obtain a server reflexive
-candidate. A Binding response will provide the agent with only a
-server reflexive candidate (also obtained from the mapped
-address). The base of the server reflexive candidate is the host
-candidate from which the Allocate or Binding request was sent. The
-base of a relayed candidate is that candidate itself. If a relayed
-candidate is identical to a host candidate (which can happen in rare
-cases), the relayed candidate MUST be discarded.
+<t>A successful Allocate response will provide the agent with a server
+reflexive candidate and a relayed candidate. If the Allocate request
+is rejected because the server lacks resources to fulfill it, the
+agent SHOULD instead send a Binding request to obtain a server
+reflexive candidate. A Binding response will provide the agent with
+only a a server reflexive candidate. 
 </t>
 
 <t>
 If an IPv6-only agent is in a network that utilizes NAT64 <xref
 target="RFC6146"/> and DNS64 <xref target="RFC6147"/> technologies, it
-may gather also IPv4 server reflexive and/or relayed candidates from
+may also gather IPv4 server reflexive and/or relayed candidates from
 IPv4-only STUN or TURN servers.  IPv6-only agents SHOULD also utilize
 IPv6 prefix discovery <xref target="RFC7050"/> to discover the IPv6
 prefix used by NAT64 (if any) and generate server reflexive candidates
@@ -1013,41 +964,33 @@ candidates are prioritized like IPv4 server reflexive candidates.
 <section anchor="sec-computing-foundations" title="Computing Foundations">
 
 <t>
-Finally, the agent assigns each candidate a foundation. The foundation
-is an identifier, scoped within a session. Two candidates MUST have
-the same foundation ID when all of the following are true:
+The agent assigns each candidate a foundation.  Two candidates MUST
+have the same foundation when all of the following are true:
 </t>
 
 <t><list style="symbols">
 
-<t> they are of the same type (host, relayed,
-server reflexive, or peer reflexive)</t>
+<t>They have the same type (host, relayed,
+server reflexive, or peer reflexive).</t>
 
-<t>their bases have the
-same IP address (the ports can be different)</t>
+<t>Their bases have the
+same IP address (the ports can be different).</t>
 
-<t>for reflexive and relayed candidates, the STUN or TURN servers used
-to obtain them have the same IP address
+<t>For reflexive and relayed candidates, the STUN or TURN servers used
+to obtain them have the same IP address.
 </t>
 
-<t>they were obtained using the same transport protocol (TCP, UDP,
-  etc.)
+<t>They were obtained using the same transport protocol (TCP, UDP).
 </t>
 
 </list></t>
-
-<t> Similarly, two candidates MUST have different foundations if their
-types are different, their bases have different IP addresses, the STUN
-or TURN servers used to obtain them have different IP addresses, or
-their transport protocols are different.
-</t>
 
 </section>
 
 <section title="Keeping Candidates Alive">
 
 <t>
-Once server reflexive and relayed candidates are allocated, they MUST
+Once server reflexive and relayed candidates are gathered, they MUST
 be kept alive until ICE processing has completed, as described in
 <xref target="sec-freeing"/>. For server reflexive candidates learned
 through a Binding request, the bindings MUST be kept alive by
@@ -1065,8 +1008,9 @@ reflexive candidate.
 <section anchor="sec-prioritizing" title="Prioritizing Candidates">
 <t>
 The prioritization process results in the assignment of a priority to
-each candidate. Each candidate for a media stream MUST have a unique
-priority that MUST be a positive integer between 1 and (2**31 - 1).
+each candidate. Each candidate MUST have a unique
+priority (unique in the scope of a component of a media stream in a session)
+that MUST be a positive integer between 1 and (2**31 - 1).
 This priority will be used by ICE to determine the order of the
 connectivity checks and the relative preference for candidates.
 </t>
@@ -1075,122 +1019,62 @@ connectivity checks and the relative preference for candidates.
 An agent SHOULD compute this priority using the formula in <xref
 target="sec-rec-form"/> and choose its parameters using the guidelines
 in <xref target="sec-guidelines"/>.  If an agent elects to use a
-different formula, ICE will take longer to converge since both agents
+different formula, ICE may take longer to converge since both agents
 will not be coordinated in their checks.
 </t>
 
-<t>
-The process for prioritizing candidates is common across the
-initiating and the responding agent.
-</t>
 
 <section anchor="sec-rec-form" title="Recommended Formula">
 
-<t>When using the formula, an agent computes the priority by
-determining a preference for each type of candidate (server reflexive,
-peer reflexive, relayed, and host), and, when the agent is multihomed,
-choosing a preference for its IP addresses. These two preferences are
-then combined to compute the priority for a candidate. That priority
-is computed using the following formula:
+<t>The recommended forumla combines a preference for the candidate
+type (server reflexive, peer reflexive, relayed, and host), a
+preference for IP address fro which the candidate was obtained, and
+component ID using the following formula:
 </t>
 
 <figure><artwork>
 <![CDATA[
 priority = (2^24)*(type preference) +
-           (2^8)*(local preference) +
+           (2^8)*(IP address preference) +
            (2^0)*(256 - component ID)
 
 ]]></artwork></figure>
 
 <t>
-The type preference MUST be an integer from 0 to 126 inclusive, and
-represents the preference for the type of the candidate (where the
-types are local, server reflexive, peer reflexive, and relayed). A 126
-is the highest preference, and a 0 is the lowest. Setting the value to
-a 0 means that candidates of this type will only be used as a last
-resort. The type preference MUST be identical for all candidates of
-the same type and MUST be different for candidates of different
-types. The type preference for peer reflexive candidates MUST be
-higher than that of server reflexive candidates. Note that candidates
-gathered based on the procedures of <xref target="sec-gathering"/>
-will never be peer reflexive candidates; candidates of these type are
-learned from the connectivity checks performed by ICE.
+The type preference MUST be an integer from 0 (lowest prefereence) to
+126 (highest preference) inclusive and MUST be identical for all
+candidates of the same type and MUST be different for candidates of
+different types. The type preference for peer reflexive candidates
+MUST be higher than that of server reflexive candidates.
 </t>
 
-<t>The local preference MUST be an integer from 0 to 65535
-inclusive. It represents a preference for the particular IP address
-from which the candidate was obtained. 65535 represents the highest
-preference, and a zero, the lowest. When there is only a single IP
-address, this value SHOULD be set to 65535. More generally, if there
+<t>The local preference MUST be an integer from 0 (lowest preference) to 65535 (highest preference) inclusive. When there is only a single IP
+address, this value SHOULD be set to 65535.  If there
 are multiple candidates for a particular component for a particular
 media stream that have the same type, the local preference MUST be
-unique for each one. In this specification, this only happens for
-multihomed hosts or if an agent is using multiple TURN servers.  If a
-host is multihomed because it is dual-stack, the local preference
+unique for each one. If an agent is dual-stack, the local preference
 should be set according to the current best practice described in <xref
 target="I-D.ietf-ice-dualstack-fairness"/>.</t>
 
 
-<t>The
-component ID is the component ID for the candidate, and MUST be
-between 1 and 256 inclusive.
-</t>
+<t>The component ID MUST be an integer between 1 and 256 inclusive.</t>
 
 
 </section>
 
 <section anchor="sec-guidelines" title="Guidelines for Choosing Type and Local Preferences">
 
-<t>One criterion for selection of the type and local preference values
-is the use of a media intermediary, such as a TURN server, a tunnel
-service such as VPN server, or NAT.  With a media intermediary, if
-media is sent to that candidate, it will first transit the media
-intermediary before being received.  Relayed candidates are one type
-of candidate that involves a media intermediary.  Another are host
-candidates obtained from a VPN interface.  When media is transited
-through a media intermediary, it can have a positive or negative
-effect on the latency between transmission and reception.  It may or
-may not increase the packet losses, because of the additional router
-hops that may be taken.  It may increase the cost of providing
-service, since media will be routed in and right back out of a media
-intermediary run by a provider.  If these concerns are important, the
-type preference for relayed candidates must be carefully chosen. The
-RECOMMENDED values are 126 for host candidates, 100 for server
-reflexive candidates, 110 for peer reflexive candidates, and 0 for
-relayed candidates.</t>
+<t>The RECOMMENDED values for type preferences are 126 for host
+candidates, 110 for peer reflexivec andidates, 100 for server
+reflexive candidates, and 0 for relayed candidates.</t>
 
-<t>Furthermore, if an agent is multihomed and has multiple IP
-addresses, the recommendation in <xref target=
-"I-D.ietf-ice-dualstack-fairness"/> should be followed.  If multiple
-TURN servers are used, local priorities for the candidates obtained
-from the TURN servers are chosen in a similar fashion as for
-multihomed local candidates: the local preference value is used to
-indicate a preference among different servers but the preference MUST
-be unique for each one.</t>
+<t>If an agent is multihomed and has multiple IP
+addresses, the recommendations in <xref target=
+"I-D.ietf-ice-dualstack-fairness"/> SHOULD be followed.</t>
 
-<t>Another criterion for selection of preferences is IP address
-family.  ICE works with both IPv4 and IPv6.  It provides a transition
-mechanism that allows dual-stack hosts to prefer connectivity over
-IPv6, but to fall back to IPv4 in case the v6 networks are
-disconnected. Implementation should follow the guidelines from <xref
-target= "I-D.ietf-ice-dualstack-fairness"/> to avoid excessively delays
-in the connectivity check phase if broken paths exist.</t>
-
-<t>Another criterion for selecting preferences is topological
-awareness. This is most useful for candidates that make use of
-intermediaries. In those cases, if an agent has preconfigured or
-dynamically discovered knowledge of the topological proximity of the
-intermediaries to itself, it can use that to assign higher local
-preferences to candidates obtained from closer intermediaries.</t>
-
-<t>Another criterion for selecting preferences might be security or
-privacy.  If a user is a telecommuter, and therefore connected to a
-corporate network and a local home network, the user may prefer their
-voice traffic to be routed over the VPN or similar tunnel in order to
-keep it on the corporate network when communicating within the
-enterprise, but use the local network when communicating with users
-outside of the enterprise.  In such a case, a VPN address would have a
-higher local preference than any other address.</t>
+<t>When choosing type preferences, agents may take into account
+factors such as latency, packet loss, cost, network topology,
+security, privacy, and others.</t>
 
 
 </section>
@@ -1201,17 +1085,10 @@ higher local preference than any other address.</t>
 <section anchor="sec-el-red" title="Eliminating Redundant Candidates">
 
 <t>
-Next, the agent eliminates redundant candidates. A candidate is
-redundant if its transport address equals another candidate, and its
-base equals the base of that other candidate. Note that two candidates
-can have the same transport address yet have different bases, and
-these would not be considered redundant. Frequently, a server
-reflexive candidate and a host candidate will be redundant when the
-agent is not behind a NAT. The agent SHOULD eliminate the redundant
-candidate with the lower priority.
-</t>
-<t>
-This process is common across the initiating and responding agents.
+Next, agents (initiating and responding) eliminate redundant
+candidates. A candidate is redundant if and only if its transport
+address and base equal those of another candidate.  The agent SHOULD
+eliminate the redundant candidate with the lower priority.
 </t>
 </section>
 <!-- end full implementation -->
@@ -1220,196 +1097,67 @@ This process is common across the initiating and responding agents.
 <section anchor="sec-offer-lite" title="Lite Implementation Procedures">
 
 <t>
-Lite implementations only utilize host candidates. A lite
-implementation MUST, for each component of each media stream, allocate
-zero or one IPv4 candidates. It MAY allocate zero or more IPv6
-candidates, but no more than one per each IPv6 address utilized by the
-host. Since there can be no more than one IPv4 candidate per component
-of each media stream, if an agent has multiple IPv4 addresses, it MUST
-choose one for allocating the candidate. If a host is dual-stack, it
-is RECOMMENDED that it allocate one IPv4 candidate and one global IPv6
-address. With the lite implementation, ICE cannot be used to
-dynamically choose amongst candidates. Therefore, including more than
-one candidate from a particular scope is NOT RECOMMENDED, since only a
-connectivity check can truly determine whether to use one address or
-the other.
+Lite agents (initating and responding) only use host candidates.  It
+is RECOMMENDED that lite agents use no more than one IPv4 host
+candidate and one IPv6 host candidate.
 </t>
 
-<t>Each component has an ID assigned to it, called the component ID.
-For RTP-based media streams, unless RTCP is multiplexed in the same
-port with RTP, the RTP itself has a component ID of 1, and RTCP a
-component ID of 2. If an agent is using RTCP without multiplexing, it
-MUST obtain candidates for it.  However, absence of a component ID 2
-as such does not imply use of RTCP/RTP multiplexing, as it could also
-mean that RTCP is not used.</t>
+<t>Component IDs, foundations, and priorities follow the sames rules
+as for full agents.</t>
 
 <t>
-Each candidate is assigned a foundation. The foundation MUST be
-different for two candidates allocated from different IP addresses,
-and MUST be the same otherwise. A simple integer that increments for
-each IP address will suffice. In addition, each candidate MUST be
-assigned a unique priority amongst all candidates for the same media
-stream. This priority SHOULD be equal to:
-</t>
-
-<figure><artwork>
-<![CDATA[
-priority = (2^24)*(126) +
-           (2^8)*(IP precedence) +
-           (2^0)*(256 - component ID)
-
-]]></artwork></figure>
-
-<t>
-If a host is v4-only, it SHOULD set the IP precedence to 65535. If a
-host is v6 or dual-stack, the IP precedence SHOULD be the precedence
-value for IP addresses described in RFC 6724 <xref target="RFC6724"/>.
-</t>
-
-<t>
-Next, an agent chooses a default candidate for each component of each
-media stream. If a host is IPv4-only, there would only be one
-candidate for each component of each media stream, and therefore that
-candidate is the default. If a host is IPv6 or dual-stack, the
-selection of default is a matter of local policy. This default SHOULD
-be chosen such that it is the candidate most likely to be used with
-a peer. For IPv6-only hosts, this would typically be a globally scoped
-IPv6 address. For dual-stack hosts, the IPv4 address is RECOMMENDED.
-</t>
-
-<t>
-The procedures in this section is common across the initiating and
-responding agents.
+Lite agents SHOULD choose the candidate most likely to be used as the
+default candidate.  For dual-stack hosts, the IPv4 candidate is
+RECOMMENDED.
 </t>
 
 </section>
 
 <section anchor="sec-encoding" title="Encoding the Candidate Information">
 
-<t>
-Regardless of the agent being an Initiator or Responder Agent,
-the following parameters and their data types needs to be conveyed
-as part of the candidate exchange process. The specifics of syntax
-for encoding the candidate information is out of scope of this
-specification.
+<t>Agents (initiating and responding) needs the following information
+about candidates to be exchanged.  How this information is encoded or
+exchanged is out of scope of this specification.  The using protocol
+should provide a means for exchaning new, additional information in
+the future, including per-candidate information.
 </t>
 
 <t><list style="hanging">
 
-<t hangText="Candidate attribute"> There will be one or more of these
-  for each "media stream". Each candidate is composed of:
+<t hangText="Username Fragment and Password:"> Values used to perform
+ connectivity checks. </t>
+
+<t hangText="Lite or Full: ">Whether the agent is a lite agent or full
+agent. </t>
+
+<t hangText="Connectivity check pacing value:">The pacing value for
+connectivity checks that the agent wishes to use.  If the agent wishes
+to use a value other than default, it MUST include this in the exchange. </t>
+
+<t hangText="Extensions:">Extensions that the agent supports.</t>
+
+<t hangText="Candidates: "> For each candidiate, the following information:
 <list style="hanging">
-   <t hangText="Connection Address:"> The IP address and transport
-   protocol port of the candidate. </t>
-   <t hangText="Transport:"> An indicator of the transport protocol
-   for this candidate. This need not be present if the using protocol
-   will only ever run over a single transport protocol. If it runs
-   over more than one, or if others are anticipated to be used in the
-   future, this should be present. </t>
-   <t hangText="Foundation:"> A sequence of up to 32 characters.</t>
-   <t hangText="Component-ID:"> This would be present only if the using
-   protocol were utilizing the concept of components. If it is, it
-   would be a positive integer that indicates the component ID for
-   which this is a candidate. </t>
-   <t hangText="Priority:"> An encoding of the 32-bit priority
-   value. </t>
-   <t hangText="Candidate Type:"> The candidate type, as defined in
-   ICE. </t>
-   <t hangText="Related Address and Port:"> The related IP address and
-   port for this candidate, as defined by ICE. These MAY be omitted or
-   set to invalid values if the agent does not want to reveal them,
-   e.g., for privacy reasons.
+   <t hangText="Address:"> The IP address and transport protocol
+   port. </t>
+   <t hangText="Transport protocol:"> As defined. </t>
+   <t hangText="Foundation:"> As defined.</t>
+   <t hangText="Component ID:"> As defined.</t>
+   <t hangText="Priority:"> As defined. </t>
+   <t hangText="Type:"> As defined. </t>
+   <t hangText="Related Address:"> As defined. MAY be omitted or
+   set to invalid values if the agent does not want to reveal them.
    </t>
-   <t hangText="Extensibility Parameters:"> The using protocol should
-   define some means for adding new per-candidate ICE parameters in
-   the future. </t>
 </list></t>
-
-<t hangText="Lite Flag:"> If ICE lite is used by the using protocol,
-  it needs to convey a boolean parameter which indicates whether the
-  implementation is lite or not. </t>
-
-<t hangText="Connectivity check pacing value:"> If an agent wants to
-use other than the default pacing values for the connectivity checks,
-it MUST indicate this in the ICE exchange. </t>
-
-<t hangText="Username Fragment and Password:"> The using protocol has
-to convey a username fragment and password. The username fragment MUST
-contain at least 24 bits of randomness, and the password MUST contain
-at least 128 bits of randomness. </t>
-
-
-<t hangText="ICE extensions:"> In addition to the per-candidate
-  extensions above, the using protocol should allow for new
-  media-stream or session-level attributes (ice-options).
-</t>
 
 </list></t>
 
 <t>
-If the using protocol is using the ICE mismatch feature, a way is
-needed to convey this parameter in answers. It is a boolean flag.
-</t>
-
-<t>
-The exchange of parameters is symmetric; both agents need to send the
-same set of attributes as defined above.
-</t>
-
-<t>
-The using protocol may (or may not) need to deal with backwards
-compatibility with older implementations that do not support ICE. If
-the fallback mechanism is being used, then presumably the using
-protocol provides a way of conveying the default candidate (its IP
-address and port) in addition to the ICE parameters.
-</t>
-
-
-<t>
-STUN connectivity checks between agents are authenticated using the
-short-term credential mechanism defined for STUN [RFC5389].  This
-mechanism relies on a username and password that are exchanged through
-protocol machinery between the client and server. The username part of
-this credential is formed by concatenating a username fragment from
-each agent, separated by a colon.  Each agent also provides a
-password, used to compute the message integrity for requests it
-receives.  The username fragment and password are exchanged between
-the peers.  In addition to providing security, the username provides
-disambiguation and correlation of checks to media streams.  See
-Appendix B.4 for motivation.
-</t>
-
-<t>
-If the initiating agent is a lite implementation, it MUST indicate
-this when sending its candidates .
-</t>
-
-<t>
-ICE provides for extensibility by allowing an agent to include a
-series of tokens that identify ICE extensions as part
-of the candidate exchange process.
-</t>
-
-<t>
-Once an agent has sent its candidate information, that agent MUST be
+Once an agent has sent its candidate information, it MUST be
 prepared to receive both STUN and media packets on each candidate. As
 discussed in <xref target="sec-send-media"/>, media packets can be
 sent to a candidate prior to its appearance as the default destination
 for media.
-</t>
-
-</section>
-
-<section anchor="sec-verify" title="Verifying ICE Support">
-
-<t>
-Certain middleboxes, such as ALGs, may alter the ICE candidate
-information that breaks ICE. If the using protocol is vulnerable to
-this kind of changes, called ICE mismatch, the responding agent needs
-to detect this and signal this back to the initiating agent. The
-details on whether this is needed and how it is done is defined by the
-usage specifications. One exception to the above is that an initiating
-agent would never indicate ICE mismatch.
 </t>
 
 </section>
@@ -1419,9 +1167,10 @@ agent would never indicate ICE mismatch.
 <section anchor="sec-candidate_proc" title="ICE Candidate Processing">
 
 <t>
-Once an agent has gathered its candidates and exchanged candidates with its peer
-(<xref target="sec-gathering_exchange"/>), it will determine its own role. In addition,
-full implementations will form CHECK LISTs, and begin performing connectivity checks with the peer.
+Once a full agent (initiating or responding) has gathered its
+candidates and received candidates from its peer, it will form CHECK
+LISTs and perform connectivity checks.  All agents (full and lite)
+respond to connectivity checks.
 </t>
 
 <section anchor="sec-candidate_proc_full" title="Procedures for Full Implementation">
@@ -1430,102 +1179,24 @@ full implementations will form CHECK LISTs, and begin performing connectivity ch
 <section anchor="sec-role" title="Determining Role">
 
 <t>
-For each session, each agent (Initiating and Responding) takes on a
-role. There are two roles -- controlling and controlled. The
-controlling agent is responsible for the choice of the final candidate
-pairs used for communications. For a full agent, this means nominating
-the candidate pairs that can be used by ICE for each media stream, and
-for updating the peer with the ICE's selection, when needed. The
-controlled agent is told which candidate pairs to use for each media
-stream, and does not require updating the peer to signal this
-information. The sections below describe in detail the actual
-procedures followed by controlling and controlled nodes.
+If both agents are full or both agents are lite, the initiating agent
+MUST choose the controlling role and the responding agent MUST choose
+the controlled role.  If one agent is full and the other lite, the
+full agent MUST choose the controlling role and the lite agent MUST
+choose the controlled role.
 </t>
 
 <t>
-The rules for determining the role and the impact on behavior are as
-follows:
-</t>
-
-<t><list style="hanging">
-<t hangText="Both agents are full:"> The Initiating Agent which
-started the ICE processing MUST take the controlling role, and the
-other MUST take the controlled role. Both agents will form check
-lists, run the ICE state machines, and generate connectivity
-checks. The controlling agent will execute the logic in <xref
-target="sec-conclude-full"/> to nominate pairs that will be selected
-by ICE, and then both agents end ICE as described in <xref
-target="sec-conc-state"/>.
-
-</t>
-
-<t hangText="One agent full, one lite:"> The full agent MUST take the
-controlling role, and the lite agent MUST take the controlled
-role. The full agent will form CHECK LISTs, run the ICE state
-machines, and generate connectivity checks. That agent will execute
-the logic in <xref target="sec-conclude-full"/> to nominate pairs that
-will be selected by ICE, and use the logic in <xref
-target="sec-conc-state"/> to end ICE. The lite implementation will
-just listen for connectivity checks, receive them and respond to them,
-and then conclude ICE as described in <xref
-target="sec-lite-conclude"/>. For the lite implementation, the state
-of ICE processing for each media stream is considered to be Running,
-and the state of ICE overall is Running.
-</t>
-
-<t hangText="Both lite:"> The Initiating Agent which started the ICE
-processing MUST take the controlling role, and the other MUST take the
-controlled role. In this case, no connectivity checks are ever
-sent. Rather, once the candidates are exchanged, each agent performs
-the processing described in <xref target="sec-conclude"/> without
-connectivity checks. It is possible that both agents will believe they
-are controlled or controlling. In the latter case, the conflict is
-resolved through glare detection capabilities in the signaling
-protocol enabling the candidate exchange. The state of ICE processing
-for each media stream is considered to be Running, and the state of
-ICE overall is Running.
-</t>
-</list>
+An agent MUST NOT change roles unless either a role conflict is
+detected (procedures for which are defined in <xref
+target="sec-role-conflict"/>) or a full agents changes to a
+lite agent as part of an ICE restart.
 </t>
 
 <t>
-Once the roles are determined for a session, they persist througout
-the lifetime of the session. The roles can be re-determined as part
-of an ICE restart (<xref target="sec-restart"/>), but an ICE agent
-MUST NOT re-determine the role as part of an ICE restart unless one
-or more of the following criteria is fulfilled:
-</t>
-
-<t><list style="hanging">
-<t hangText="Full becomes lite:">
-If the controlling agent is full, and switches to lite, the roles MUST be
-re-determined if the peer agent is also full.
-</t>
-
-<t hangText="Role conflict:">
-If the ICE restart causes a role conflict, the roles might be
-re-determined due to the role conflict procedures in <xref target="sec-role-conflict"/>.
-</t>
-
-</list>
-</t>
-
-<t>
-NOTE: There are certain 3PCC scenarios where an ICE restart might cause
-a role conflict.
-</t>
-
-<t>
-NOTE: The ICE agents needs to inform each other whether they are full
-or lite before the roles are determined. The mechanism for that is
-signalling protocol specific, and outside the scope of the document.
-</t>
-
-<t>
-An ICE agent MUST be prepared that the peer might re-determine the roles
-as part of any ICE restart, even if the criteria for doing so are not
-fulfilled. This can happen if the peer is compliant with an older version
-of this specification.
+An agent MUST be prepared for its peer to change roles as part of an
+ICE restart. This can happen if the peer is compliant with an older
+version of this specification.
 </t>
 
 </section>
@@ -2115,11 +1786,12 @@ permission active until ICE concludes.
 short-term credential mechanism.
 </t>
 <t>The username for the credential is formed by concatenating the
-username fragment provided by the peer with the username fragment
-of the agent sending the request, separated by a colon (":").
+username fragment provided by the peer with the username fragment of
+the agent sending the request, separated by a colon (":").  The
+username fragment MUST contain at least 24 bits of randomness
 </t>
-<t>The password is equal to the password provided by
-the peer.
+<t>The password is equal to the password provided by the peer.  The
+password MUST contain at least 128 bits of randomness.
 </t>
 <t>For example, consider the case where ICE agent L is the
 Initiating agent and ICE agent R is the Responding agent. Agent L

--- a/draft-ietf-ice-rfc5245bis.xml
+++ b/draft-ietf-ice-rfc5245bis.xml
@@ -298,8 +298,8 @@ the TURN request will create a binding on each NAT, but only the
 outermost server reflexive candidate (the one nearest the TURN server)
 will be discovered by the agent. If the agent is not behind a NAT,
 then the base candidate will be the same as the server reflexive
-candidate and the server reflexive candidate is redundant and will be
-eliminated.
+candidate and the server reflexive candidate is redundant and the
+lower priority candidate will be eliminated.
 </t>
 
 <t>
@@ -423,7 +423,7 @@ NATs.
 </t>
 
 <t>
-The agent works through this CHECK LIST by sending a STUN request for
+The agent works through this check list by sending a STUN request for
 the next candidate pair on the list periodically. These are called
 ORDINARY CHECKS.
 </t>
@@ -701,7 +701,8 @@ candidates the base is the same as the relayed candidate.
 candidates and control candidates freezing.
 </t>
 
-<t hangText="Local Candidate:">A candidate that an agent has obtained and may send it its peer.
+<t hangText="Local Candidate:">A candidate that an agent has obtained
+and may send it its peer.
 </t>
 
 <t hangText="Remote Candidate:">A candidate that an agent received
@@ -743,7 +744,8 @@ media stream that have been validated by a successful STUN
 transaction.
 </t>
 
-<t hangText="Check List Set:"> An ordered list of CHECK LISTs.
+<t hangText="Check List Set:"> The ordered list of all check lists.
+The order is determined by each ICE usage.
 </t>
 
 
@@ -1048,7 +1050,8 @@ different types. The type preference for peer reflexive candidates
 MUST be higher than that of server reflexive candidates.
 </t>
 
-<t>The local preference MUST be an integer from 0 (lowest preference) to 65535 (highest preference) inclusive. When there is only a single IP
+<t>The local preference MUST be an integer from 0 (lowest preference) 
+to 65535 (highest preference) inclusive. When there is only a single IP
 address, this value SHOULD be set to 65535.  If there
 are multiple candidates for a particular component for a particular
 media stream that have the same type, the local preference MUST be
@@ -1205,85 +1208,50 @@ version of this specification.
 <section anchor="sec-forming" title="Forming the Check Lists">
 
 <t>
-There is one CHECK LIST per in-use media stream resulting from the
-candidate exchange.  To form the CHECK LIST for a media stream, the
-agent forms candidate pairs, computes a candidate pair priority,
-orders the pairs by priority, prunes them, removes lower-priority
-candidates and sets their states. These steps are described in this section.
-If a CHECK LIST is updated (e.g, due to detection of peer reflexive
-candidates), the agent will re-perform the steps for the updated
-CHECK LIST.
+There is one check list for each media stream.  To form a check list,
+an agent (initiaing and responding) forms candidate pairs, computes
+pair priorities, orders pairs by priority, prunes pairs, removes
+lower-priority pairs, and sets check list states. If candidates are
+added to a check list (e.g, due to detection of peer reflexive
+candidates), the agent will re-perform these steps for the updated
+check list.
 </t>
 <section title="Check List State">
-<t>Each CHECK LIST has a state, which captures the state of ICE checks
-for the media stream associated with the CHECK LIST. The states are:</t>
+<t>Each check list has one of the following states:</t>
 <t><list style="hanging">
-<t hangText="Running:"> In this state, ICE checks are still in
-progress for this media stream. Check lists are initially set
-to the Running state.
+<t hangText="Running:">Not yet in the Completed or Failed state.
 </t>
-<t hangText="Completed:"> In this state, ICE checks have produced
-selected pairs for each component of the media stream.
+<t hangText="Completed:">For each component of the media stream, there
+is at least one candidate pair in the Succeeded state.
 </t>
-<t hangText="Failed:"> In this state, the ICE checks have not
-completed successfully for this media stream.
+<t hangText="Failed:">For any component of the media stream, all
+candidate pairs are in the Failed state.
 </t>
 </list></t>
-<t>A CHECK LIST with at least one pair that is
-Waiting is called an active CHECK LIST, and a CHECK LIST with all
-pairs Frozen is called a frozen CHECK LIST.
+<t>Additionally, a check list with at least one pair in the waiting
+state is called "active", while a check list with all pairs in the
+frozen state is called "frozen".
 </t>
+
 </section>
 
 <section title="Forming Candidate Pairs">
 
 <t>
-First, the agent takes each of its candidates for a media stream
-(called LOCAL CANDIDATES) and pairs them with the candidates it
-received from its peer (called REMOTE CANDIDATES) for that media
-stream. A local candidate is
-paired with a remote candidate if and only if the two candidates have
-the same component ID and have the same IP address version. It is
-possible that some of the local candidates won't get paired with
-remote candidates, and some of the remote candidates won't get paired
-with local candidates. This can happen if one agent doesn't include
-candidates for the all of the components for a media stream. If this
-happens, the number of components for that media stream is effectively
-reduced, and considered to be equal to the minimum across both agents
-of the maximum component ID provided by each agent across all
-components for the media stream.
+The agent pairs each local candidate with each remote candidate for
+the same component of the same media stream with the same IP
+address version and transport protocol.
 </t>
 
-<t>In the case of RTP, this would happen when one agent provides
-candidates for RTCP, and the other does not. As another example, the
-initiating agent can multiplex RTP and RTCP on the same port <xref
-target="RFC5761"/>. However, since the initiating agent doesn't know
-if the peer agent can perform such multiplexing, it includes
-candidates for RTP and RTCP on separate ports. If the peer agent can
-perform such multiplexing, it would include just a single component
-for each candidate -- for the combined RTP/RTCP mux. ICE would end up
-acting as if there was just a single component for this candidate.
-</t>
-
-<t> With IPv6 it is common for a host to have multiple host candidates
-for each interface. To keep the amount of resulting candidate pairs
-reasonable and to avoid candidate pairs that are highly unlikely to
-work, IPv6 link-local addresses <xref target="RFC4291"/> MUST NOT be
-paired with other than link-local addresses. </t>
+<t>To reduce the number of candidate pairs and to avoid candidate
+pairs that are highly unlikely to work, IPv6 link-local addresses
+<xref target="RFC4291"/> MUST NOT be paired with other than link-local
+addresses. </t>
 
 <t>
-The candidate pairs whose local and remote candidates are both the
-default candidates for a particular component is called the
-default candidate pair for that component. This is the pair that
-would be used to transmit media if both agents had not
-been ICE aware.
-</t>
-
-<t>
-In order to aid understanding, <xref target="fig-check-model"/> shows
-the relationships between several key concepts -- transport addresses,
-candidates, candidate pairs, and CHECK LISTs, in addition to
-indicating the main properties of candidates and candidate pairs.
+<xref target="fig-check-model"/> shows the properties of and
+relationships between transport addresses, candidates, candidate
+pairs, and check lists.
 </t>
 
 <figure title="Conceptual Diagram of a Check List"
@@ -1340,23 +1308,23 @@ indicating the main properties of candidates and candidate pairs.
 <section anchor="sec-comp-pair-prio" title="Computing Pair Priority and Ordering Pairs">
 
 <t>
-Once the pairs are formed, a candidate pair priority is computed. Let
-G be the priority for the candidate provided by the controlling
-agent. Let D be the priority for the candidate provided by the
-controlled agent. The priority for a pair is computed as:
+The agent computes a priority for each candidate pair. Let G be the
+priority for the candidate provided by the controlling agent. Let D be
+the priority for the candidate provided by the controlled agent. Let X
+be 1 if G is greater than D, and 0 otherwise.  The priority for a pair
+is computed as:
 </t>
 
 <t><list style="empty">
 <t>
-pair priority = 2^32*MIN(G,D) + 2*MAX(G,D) + (G>D?1:0)
+pair priority = 2^32*MIN(G,D) + 2*MAX(G,D) + X
 </t>
 </list></t>
 
 <t>
-Where G>D?1:0 is an expression whose value is 1 if G is greater than
-D, and 0 otherwise. Once the priority is assigned, the agent sorts the
-candidate pairs in decreasing order of priority. If two pairs have
-identical priority, the ordering amongst them is arbitrary.
+The agent sorts each check list in decreasing order of candidate pair
+priority. If two pairs have identical priority, the ordering amongst
+them is arbitrary.
 </t>
 
 </section>
@@ -1364,20 +1332,12 @@ identical priority, the ordering amongst them is arbitrary.
 <section title="Pruning the Pairs">
 
 <t>
-This sorted list of candidate pairs is used to determine a sequence of
-connectivity checks that will be performed. Each check involves
-sending a request from a local candidate to a remote candidate. Since
-an agent cannot send requests directly from a reflexive candidate
-(server reflexive or peer reflexive), but only from its base, the
-agent next goes through the sorted list of candidate pairs. For each
-pair where the local candidate is reflexive, the candidate MUST be
-replaced by its base. Once this has been done, the agent MUST prune
-the list. This is done by removing a pair if its local and remote candidates
-are identical to the local and remote candidates of a pair higher up on
-the priority list. The result is a sequence of ordered candidate
-pairs, called the CHECK LIST for that media stream.
+The agent prunes each check list.  This is done by removing a
+candidate pair if it is redundant with a higher priority candidate
+pair in the same check list.  Two candidate pairs are redundant if
+their local candidates have the same base and their remote candidates
+are identical.
 </t>
-
 </section>
 
 <section title="Removing lower-priority Pairs">
@@ -1385,15 +1345,10 @@ pairs, called the CHECK LIST for that media stream.
 <t>
 In order to limit the attacks described in <xref
 target="sec-ice-hammer"/>, an agent MUST limit the total number of
-connectivity checks the agent performs across all CHECK LISTs to a
-specific value, and this value MUST be configurable. A default of 100
-is RECOMMENDED. This limit is enforced by discarding the
-lower-priority candidate pairs until there are less than 100. It is
-RECOMMENDED that a lower value be utilized when possible, set to the
-maximum number of plausible checks that might be seen in an actual
-deployment configuration. The requirement for configuration is meant
-to provide a tool for fixing this value in the field if, once
-deployed, it is found to be problematic.
+candidate pairs across all check lists, and this limit MUST be
+configurable. A default of 100 is RECOMMENDED.  This limit is enforced
+by discarding the lower-priority candidate pairs until there are less
+than limit.
 </t>
 
 </section>
@@ -1401,41 +1356,33 @@ deployed, it is found to be problematic.
 <section title="Computing Candidate Pair States">
 
 <t>
-Each candidate pair in the CHECK LIST has a foundation and a state.
-The foundation is the combination of the foundations of the local and
-remote candidates in the pair. The state is assigned once the check
-list for each media stream has been computed. There
-are five potential values that the state can have:
+Each candidate pair in the check list has one of the following states:
 </t>
 
 <t><list style="hanging">
+<t hangText="Frozen:"> A check has not been sent for this pair,
+and a check can not be sent until the pair is unfrozen.
+</t>
+
 <t hangText="Waiting:"> A check has not been sent for this pair, but
-can be sent as soon as the pair is chosen based on the criteria for selecting
-for which candidate pair a check is to be sent.
+the pair is not Frozen.
 </t>
 
 <t hangText="In-Progress:"> A check has been sent for this pair, but
-the transaction is in progress.
+has not completed.
 </t>
 
-<t hangText="Succeeded:"> A check has been sent for this pair, and
-produced a successful result.
+<t hangText="Succeeded:"> A check has been sent for this pair, and has
+completed with a successful result.
 </t>
 
-<t hangText="Failed:"> A check has been sent for this pair, and
-failed (a response to the check was never received, or a failure
-response was received).
-</t>
-
-<t hangText="Frozen:"> A check for this pair has not been sent,
-and it can not be sent until the pair is unfrozen and moved into the
-Waiting state.
+<t hangText="Failed:"> A check has been sent for this pair, and has
+completed with a failure result (a failure response or timeout).
 </t>
 </list></t>
 
 <t>
-As ICE runs, the pairs will move between states as shown in <xref
-target="fig-state-fsm"/>.
+Pairs move between states as shown in <xref target="fig-state-fsm"/>.
 </t>
 
 <figure title="Pair State FSM" anchor="fig-state-fsm" align="center"><artwork>
@@ -1452,8 +1399,8 @@ target="fig-state-fsm"/>.
          |
          V
    +-----------+         +-----------+
-   |           |         |           |
-   |           | perform |           |
+   |           | send    |           |
+   |           | check   |           |
    |  Waiting  |-------->|In-Progress|
    |           |         |           |
    |           |         |           |
@@ -1480,50 +1427,32 @@ target="fig-state-fsm"/>.
    +-----------+         +-----------+
 ]]></artwork></figure>
 
-<t>
-The initial states for each pair in a CHECK LIST are computed by
-performing the following sequence of steps:
-</t>
-
 <t><list style="numbers">
 
-<t>The CHECK LISTs are placed in an ordered list (the order is determined
-by each ICE usage), called the CHECK LIST SET.
-</t>
-
-<t>The agent sets all of the candidate pairs in the CHECK LIST SET
-to the Frozen state.
-</t>
-
-<t>The agent sets all of the CHECK LISTs in the CHECK LIST SET to the Running
-state.
-</t>
-
-<t>The agent examines each CHECK LIST, starting from the first
-CHECK LISTs in the CHECK LIST SET, in the following way:
-<list style="symbols">
 <t>
-For each foundation, the candidate pair with the lowest
-component ID (in case of multiple such pairs, the pair with the highest
-priority) is placed in the Waiting state, unless a candidate pair
-associated with the same foundation has already been put in the Waiting
-state in one of the other examined CHECK LISTs. This will ensure that,
-within the CHECK LIST SET, only one pair with a given foundation
-is initially placed in the Waiting state, while other pairs with the same
-foundation remain in the Frozen state.
-</t>
-</list></t>
-
-</list></t>
-
-<t>NOTE: The procedures above are different from RFC5245, where only candidate pairs
-in the first CHECK LIST of the CHECK LIST SET were initially placed in the Waiting
-state.
+The agent initially places all candidate pairs in the Frozen state.
 </t>
 
 <t>
-The table in <xref target="fig-state-initial"/> illustrates how the
-initial states of the candidate pairs in the CHECK LIST SET.
+For each foundation, the agent sets the state of exactly one candidate
+pair to the Waiting state (unfreezing it).  The candidate pair to
+unfreeze is choosen by finding the first candidate pair (ordered by
+lowest component ID and then highest priority if component IDs are
+equal) in the first check list in the check list set that has that
+foundation.
+</t>
+
+</list></t>
+
+<t>NOTE: The procedures above are different from RFC5245, where only
+candidate pairs in the first check list of were initially placed in
+the Waiting state.  Now it applies to candidate pairs in the the first
+check list which have that foundation, even if the first check list to
+have that foundation is not the first check list in the check list set.
+</t>
+
+<t>
+The table in <xref target="fig-state-initial"/> illustrates an example.
 </t>
 
 <figure title="Initial Pair State" anchor="fig-state-initial" align="center"><artwork>
@@ -1531,8 +1460,8 @@ initial states of the candidate pairs in the CHECK LIST SET.
 
 Table legend:
 
-Each row (m1, m2,...) represents a CHECK LIST associated with a media
-stream. m1 represents the first CHECK LIST in the CHECK LIST SET.
+Each row (m1, m2,...) represents a check list associated with a media
+stream. m1 represents the first check list in the check list set.
 
 Each column (f1, f2,...) represents a foundation. Every candidate pair
 within a given column share the same foundation.
@@ -1541,7 +1470,7 @@ f-cp represents a candidate pair in the Frozen state.
 
 w-cp represents a candidate pair in the Waiting state.
 
-1. The agent sets all of the pairs in the CHECK LIST SET to the Frozen
+1. The agent sets all of the pairs in the check list set to the Frozen
 state.
 
       f1    f2    f3    f4    f5
@@ -1556,7 +1485,7 @@ m3 | f-cp                    f-cp
 2. For each foundation, the candidate pair with the lowest component ID
 is placed in the Waiting state, unless a candidate pair associated with
 the same foundation has already been put in the Waiting state in one of
-the other examined CHECK LISTs in the CHECK LIST SET.
+the other examined check lists in the check list set.
 
       f1    f2    f3    f4    f5
     -----------------------------
@@ -1567,23 +1496,23 @@ m2 | f-cp  f-cp  f-cp  w-cp
 m3 | f-cp                    w-cp
 
 
-In the first CHECK LIST (m1) the candidate pair for each foundation is
+In the first check list (m1) the candidate pair for each foundation is
 placed in the Waiting state, as no pairs for the same foundations have
 yet been placed in the Waiting state.
 
-In the second CHECK LIST (m2) the candidate pair for foundation f4 is
+In the second check list (m2) the candidate pair for foundation f4 is
 placed in the Waiting state. The candidate pair for foundations f1, f2
 and f3 are kept in the Frozen state, as candidate pairs for those
 foundations have already been placed in the Waiting state (within check
 list m1).
 
-In the third CHECK LIST (m3) the candidate pair for foundation f5 is
+In the third check list (m3) the candidate pair for foundation f5 is
 placed in the Waiting state. The candidate pair for foundation f1 is
 kept in the Frozen state, as a candidate pair for that foundation have
-already been placed in the Waiting state (within CHECK LIST m1).
+already been placed in the Waiting state (within check list m1).
 
-Once each CHECK LIST have been processed, one candidate pair for each
-foundation in the CHECK LIST SET has been placed in the Waiting state.
+Once each check list have been processed, one candidate pair for each
+foundation in the check list set has been placed in the Waiting state.
 
 ]]></artwork></figure>
 
@@ -1592,96 +1521,68 @@ foundation in the CHECK LIST SET has been placed in the Waiting state.
 
 <section title="ICE State">
 <t>
-ICE processing across the CHECK LIST SET has a state associated
-with it. This state is set to Running while ICE processing is under
-way. The state is set to Completed when ICE processing is complete
-and set to Failed if it failed without success.
+The ICE agents has a state determined by the state of the check
+lists. The state is Completed if all check lists are Completed, Failed
+if any check list is Failed, and Running otherwise.
 </t>
 </section>
 
 <section anchor="sec-periodic" title="Scheduling Checks">
-<section anchor="sec-periodic-queue" title="Triggered Check Queue">
 <t>
-Once the agent has computed the CHECK LISTs and created the CHECK LIST SET,
-as described in <xref target="sec-forming"/>, the agent will begin performing
-connectivity checks (ordinary and triggered). For triggered connectivity checks,
-the agent maintains a FIFO queue for each CHECK LIST, called the TRIGGERED CHECK
-QUEUE, which contains candidate pairs for which checks are to be sent at the next
-available opportunity.
+When candidate pairs are unfrozen, the agent perfoms connectivity
+checks.  Connectivity checks are govererned by a timer called Ta.  The
+agent chooses a candidate pair and sends the first check by by sending
+a STUN request from the base of the local candiditate to the remote
+candidate following the procedures in <xref
+target="sec-connectivity_check"/>.  Then every time Ta fires, it
+chooses a candidate pair and sends a check.  After sending these
+checks, the agent sets the candidate pair's state to In-Progress.
 </t>
-</section>
 
-<section anchor="sec-periodic-perform" title="Performing Connectivity Checks">
-<t>The generation of ordinary and triggered connectivity checks is govererned
-by timer Ta. As soon as the initial states for the candidate pairs in the
-CHECK LIST SET have been set, a check is performed for a candidate pair
-within the first CHECK LIST in the Running state, following
-the procedures in <xref target="sec-connectivity_check"/>. After that,
-whenever Ta fires the next CHECK LIST in the Running state in the CHECK LIST SET
-is selected, and a check is performed for a candidate within that CHECK LIST.
-After the last CHECK LIST in the Running state in the CHECK LIST SET has been
-processed, the first CHECK LIST is selected again. Etc.
-</t>
-<t>NOTE: When timer Ta fires, and the agent processes a CHECK LIST, if no check
-is performed for a pair in the CHECK LIST (based on the rules below), the agent
-can immediately select the next CHECK LIST in the Running state, without waiting
-for timer Ta to expire again.
+<t>The agent chooses a candidate pair by first choosing a check list
+and second choosing a candidate pair within that check list.  If the
+process of choosing a candidate pair within a check list results in no
+candidate pair, the agent follows the same procedure again to choose a
+different heck list until a candidate pair is chosen.
 </t>
 
 <t>
-Whenever Ta fires, the agent will perform a check for a candidate pair within
-the selected CHECK LIST as follows:
-<list style="symbols">
-<t>If the TRIGGERED CHECK QUEUE associated with the CHECK LIST contains
-one or more candidate pairs, the agent removes the top pair from the
-queue, performs a connectivity check on that pair and puts the candidate pair
-state to In-Progress; or
+The first time the agent chooses a check list, it chooses the first
+check list in the check list set that is in the Running state.
+Subsequent times, the agent chooses the next check list in the check
+list set that is in the Running state.  If there is no such check list
+in the Running state, the agent chooses the first such check list in
+the check list set again, thus cycling through all the check lists in
+the Running state repeatedly.
 </t>
 
-<t>If the TRIGGERED CHECK QUEUE associated with the CHECK LIST is empty, and
-if there are one or more candidate pairs in the Waiting state, the agent selects
-the highest-priority candidate pair (if there are multiple pairs with the same
-priority, the pair with the lowest component ID is selected) in the Waiting
-state, performs a connectivity check on that pair and puts the candidate pair
-par state to In-Progress; or
+<t>
+The agent chooses a candidate pair within a check list by first
+examining a FIFO queue of candidate pairs called the TRIGGERED CHECK
+QUEUE. If the triggered check queue is not empty, the agent removes
+the first pair from the queue and chooses that pair.  If the triggered
+check queue is empty, the agent chooses the first candidate pair in
+the Waiting state.
 </t>
 
-<t>If there is no candidate pair in the Waiting state, and if there are one or
-more pairs in the Frozen state, for each pair in the Frozen state the the agent
-checks the foundation associated with the pair. For a given foundation, if there
-is no pair (in any CHECK LIST in the CHECK LIST SET) in the Waiting or In-Progress state,
-the agent performs a connectivity check on the pair and puts the pair state to In-Prograss.
-If, for the same foundation, there are one or more pairs in the Waiting or In-Progress state,
-(in any CHECK LIST in the CHECK LIST SET) the agent does not perform a connectivity check
-on the pair.
+<t>
+If there is no candidate pair in the Waiting state, the agent chooses
+the first candidate pair in the check list which is in the Frozen
+state and which has an inactive foundation.  An foundation is inactive
+if none of the candidates (across all check lists) in the In-Progress
+or Waiting states have that foundation.
 </t>
 
-</list></t>
-
-<t>Once the agent has selected a candidate pair, for which a connectivity check is to
-be performed, the agent performs the check by sending a STUN request from the base associated
-with the local candiditate of the pair to the remote candidate of the pair, as described in
-<xref target="sec-send-check"/>.
+<t>
+If no such Frozen candidate pair exists, no candidate pair is chosen
+for the check list, and the agent may choose another check list.
 </t>
 
-<t>Based on local policy, an agent MAY choose to terminate perfoming the
-connectivity checks for one or more checks lists in the CHECK LIST SET
-at any time. However, only the controlling agent is allowed to
-conclude ICE (<xref target="sec-conclude"/>).
+<t>An agent MAY terminate connectivity checks for specific checks
+lists at any time. However, only the controlling agent may conclude
+ICE (<xref target="sec-conclude"/>).
 </t>
 
-<t>To compute the message integrity for the check, the agent uses the
-remote username fragment and password learned from the candidate
-information obtained from its peer. The local username fragment is
-known directly by the agent for its own candidate.
-</t>
-
-<t>The Initiator performs the ordinary checks on receiving the candidate
-information from the Peer (responder) and having formed the CHECK LISTs.
-On the other hand the responding agent either performs the triggered or
-ordinary checks as described above.
-</t>
-</section>
 </section>
 <!-- end of full implementation -->
 </section>
@@ -1689,20 +1590,9 @@ ordinary checks as described above.
 <section anchor="sec-candidate_proc_lite" title="Lite Implementation Procedures">
 
  <t>
- Lite implementations skips most of the steps in <xref
- target="sec-candidate_proc"/> except for verifying the peer's ICE
- support and determining its role in the ICE processing.
- </t>
-
- <t>
- On determining the role for a lite implementation being the
- controlling agent means selecting a candidate pair based on the ones
- in the candidate exchange (for IPv4, there is only ever one pair),
- and then updating the peer with the new candidate information
- reflecting that selection, when needed (it is never needed for an
- IPv4-only host). The controlled agent is told which candidate pairs
- to use for each media stream, and no further candidate updates are
- needed to signal this information.
+ Because lite agents do not send connectivity checks, they not perform
+ the steps necessary for candidate pair and check lists states and
+ choosing check lists and candidate pairs.
  </t>
 
 </section>
@@ -1730,25 +1620,18 @@ new attributes.
 </t>
 
 <section title="PRIORITY">
-<t>The attribute MUST be set equal to the priority that would be
-assigned, based on the algorithm in <xref target="sec-prioritizing"/>,
-to a peer reflexive candidate, should one be learned as a consequence
-of this check (see <xref target="sec-learn-peer-client"/> for how peer
-reflexive candidates are learned). This priority value will be
-computed identically to how the priority for the local candidate of
-the pair was computed, except that the type preference is set to the
-value for peer reflexive candidate types.
-</t>
-<t>An ICE agent MUST include the PRIORITY attribute in a Binding
-request.
+<t>The priority attribute MUST be included in a Binding request and be
+set to value computed by the algorithm in <xref
+target="sec-prioritizing"/> for the local candidate, but with a
+candidate type preference for peer-reflexive candidates.
 </t>
 </section>
 
 <section title="USE-CANDIDATE">
-<t>The controlling ICE agent includes the USE-CANDIDATE attribute in order
-to nominate a candidate pair <xref target="sec-choose-favor"/>.
-The controlled ICE agent MUST NOT include the USE-CANDIDATE attribute in a
-Binding request.
+<t>The controlling ICE agent includes the USE-CANDIDATE attribute in
+order to nominate a candidate pair <xref target="sec-choose-favor"/>.
+The controlled ICE agent MUST NOT include the USE-CANDIDATE attribute
+in a Binding request.
 </t>
 </section>
 
@@ -1768,16 +1651,14 @@ when an ICE role conflict occurs <xref target="sec-role-conflict"/>.
 <section anchor="sec-permissions" title="Creating Permissions for Relayed Candidates">
 <t>If the connectivity check is being sent using a relayed local
 candidate, the client MUST create a permission first if it has not
-already created one previously.  It would have created one previously
-if it had told the TURN server to create a permission for the given
-relayed candidate towards the IP address of the remote candidate.  To
-create the permission, the agent follows the procedures defined in
-<xref target="RFC5766"/>.  The permission MUST be created towards the
-IP address of the remote candidate.  It is RECOMMENDED that the agent
-defer creation of a TURN channel until ICE completes, in which case
-permissions for connectivity checks are normally created using a
-CreatePermission request.  Once established, the agent MUST keep the
-permission active until ICE concludes.
+already created one previously.  To create the permission, the agent
+follows the procedures defined in <xref target="RFC5766"/>.  The
+permission MUST be created towards the IP address of the remote
+candidate.  It is RECOMMENDED that the agent defer creation of a TURN
+channel until ICE completes, in which case permissions for
+connectivity checks are normally created using a CreatePermission
+request.  Once established, the agent MUST keep the permission active
+until ICE concludes.
 </t>
 </section>
 
@@ -1787,7 +1668,7 @@ short-term credential mechanism.
 </t>
 <t>The username for the credential is formed by concatenating the
 username fragment provided by the peer with the username fragment of
-the agent sending the request, separated by a colon (":").  The
+the agent sending the request, separated by a colon (":").  Each
 username fragment MUST contain at least 24 bits of randomness
 </t>
 <t>The password is equal to the password provided by the peer.  The
@@ -1804,24 +1685,17 @@ LPASS. The responses utilize the same usernames and passwords as the
 requests (note that the USERNAME attribute is not present in the
 response).
 </t>
+
+<t>Support for backwards compatibility with RFC 3489 MUST NOT
+be assumed when performing connectivity checks. The FINGERPRINT mechanism
+MUST be used for connectivity checks.
+</t>
 </section>
 
 <section title="DiffServ Treatment">
 <t>If an ICE agent is using Diffserv Codepoint markings <xref
 target="RFC2475"/> in its media packets, the agent SHOULD apply
 those same markings to its connectivity checks.
-</t>
-</section>
-
-<section anchor="sec-send-check" title="Sending the Request">
-<t>A connectivity check is generated by sending a Binding request from
-the base associated with a local candidate to a remote candidate.
-<xref target="RFC5389"/> describes how Binding requests are constructed
-and generated.
-</t>
-<t>Support for backwards compatibility with RFC 3489 MUST NOT
-be assumed when performing connectivity checks. The FINGERPRINT mechanism
-MUST be used for connectivity checks.
 </t>
 </section>
 
@@ -1844,10 +1718,10 @@ a role conflict, a failure, or a success, according to the procedures below.
     </t>
     <t>Once the ICE agent has switched its role, the agent MUST add the
     candidate pair whose check generated the 487 error response to the
-    TRIGGERED CHECK QUEUE associated with the CHECK LIST to which the
+    triggered check queue associated with the check list to which the
     pair belongs, and set the candidate pair state to Waiting. When the
     triggered connectivity check is later performed, the
-    ICE-CONTROLLING/ICE-CONTROLLED attribute of the Binding request will
+    ice-controlling/ice-controlled attribute of the Binding request will
     indicate the agent's new role. The ICE agent MUST NOT change
     the tie-breaker value.
     </t>
@@ -1865,13 +1739,13 @@ a role conflict, a failure, or a success, according to the procedures below.
     <t>This section describes cases when the candidate pair state is set to Failed.
     </t>
     <t>NOTE: When the ICE agent sets the candidate pair state to Failed as a
-    result a connectivity check error, the agent does not change the states
+    result of a connectivity check error, the agent does not change the states
     of other candidate pairs with the same foundation.
     </t>
     <section title="Non-Symmetric Transport Addresses">
     <t>The ICE agent MUST check that the source and destination transport addresses
     in the Binding request and response are symmetric. I.e., the source IP address
-    and port of the response MUST be equal the destination IP address and port to which the
+    and port of the response MUST be equal to the destination IP address and port to which the
     Binding request was sent, and that the destination IP address and port of the response
     MUST be equal to the source IP address and port from which the Binding request was sent.
     If the addresses are not symmetric, the ICE agent MUST set the candidate pair state
@@ -1905,64 +1779,61 @@ request and response are symmetric.</t>
 
 <section anchor="sec-learn-peer-client" title="Discovering Peer Reflexive Candidates">
 
-<t>The ICE agent MUST check the mapped address from the STUN response. If the
-transport address does not match any of the local candidates that the
-agent knows about, the mapped address represents a new candidate: a
-peer reflexive candidate. Like other candidates, a peer reflexive candidate
-has a type, base, priority, and foundation. They are computed as follows:
+<t>The ICE agent MUST check the mapped address from the STUN
+response. If the transport address does not match any of the local
+candidates, the mapped address represents a new peer-reflexive
+candidate which is added to the corresponding check list.
+The type, base, priority, and foundation are computed as follows.
 </t>
 
 <t><list style="symbols">
-<t>The type is equal to peer reflexive.</t>
-<t>The base is set equal to the local candidate of the candidate pair
+<t>The type is peer-reflexive.</t>
+<t>The base is local candidate of the candidate pair
 from which the Binding request was sent.</t>
-<t>The priority is set equal to the value of the PRIORITY attribute in
+<t>The priority is value of the PRIORITY attribute in
 the Binding request.</t>
-<t>The foundation is set as described in <xref target="sec-computing-foundations"/>.</t>
+<t>The foundation is described in <xref target="sec-computing-foundations"/>.</t>
 </list></t>
-<t>The peer reflexive candidate is then added to the list of local
-candidates for the media stream. The username fragment and password
-are the same as for all other local candidates for that media stream.
-</t>
-<t>The ICE agent does not need to pair the peer reflexive
+
+<t>The ICE agent does not need to pair the peer-reflexive
 candidate with remote candidates, as a valid candiate pair will be
 created due to the procedures in <xref target="sec-valid-cons"/>.
-If an ICE agent wishes to pair the peer reflexive candidate with
-other remote candidates besides the one in the valid pair that will
+If an ICE agent wishes to pair the peer-reflexive candidate with
+remote candidates other than the one in the valid pair that will
 be generated, the agent MAY provide updated candidate information to
-the peer that includes the peer reflexive candidate. This will cause
-the peer reflexive candidate to be paired with all other remote candidates.
+the peer that includes the peer-reflexive candidate. This will cause
+the peer-reflexive candidate to be paired with all other remote candidates.
 </t>
 </section>
 
 <section anchor="sec-valid-cons" title="Constructing a Valid Pair">
-<t>The ICE agent constructs a candidate pair whose local candidate equals the
+<t>The agent constructs a candidate pair whose local candidate equals the
 mapped address of the response, and whose remote candidate equals the
 destination address to which the request was sent. This is called a
 valid pair.
 </t>
 <t>The valid pair may equal the pair that generated the connectivity check, or
-it may equal a different pair in a CHECK LIST (sometimes in a different CHECK LIST
+it may equal a different pair in a check list (sometimes in a different check list
 than the one to which the pair that generated the connectivity checks),
-or it may be a pair not currently in any CHECK LIST.
+or it may be a pair not currently in any check list.
 </t>
 <t>The ICE agent maintains a separate list, called the VALID LIST, for each check
-list in the CHECK LIST SET. The VALID LIST will contain valid pairs. Initially
-each VALID LIST is empty.
+list in the check list set. The valid list will contain valid pairs. Initially
+each valid list is empty.
 </t>
-<t>Each valid pair within the VALID LIST has a flag, called the Nominated Flag.
-When a valid pair is added to a VALID LIST, the flag value is set to 'false'.
+<t>Each valid pair within the valid list has a flag, called the Nominated Flag.
+When a valid pair is added to a valid list, the flag value is set to 'false'.
 </t>
-<t>The valid pair will be added to a VALID LIST as follows:
+<t>The valid pair will be added to a valid list as follows:
 <list style="numbers">
 <t>If the valid pair equals the pair that generated the check, the pair is added to
-the VALID LIST associated with the CHECK LIST to which the pair belongs; or
+the valid list associated with the check list to which the pair belongs; or
 </t>
-<t>If the valid pair equals another pair in a CHECK LIST, that pair is added
-to the VALID LIST associated with the CHECK LIST of that pair. The pair that
-generated the check is not added to a VALID LIST; or
+<t>If the valid pair equals another pair in a check list, that pair is added
+to the valid list associated with the check list of that pair. The pair that
+generated the check is not added to a valid list; or
 </t>
-<t>If the valid pair is not in any CHECK LIST, the agent computes the priority
+<t>If the valid pair is not in any check list, the agent computes the priority
 for the pair based on the priority of each candidate, using the
 algorithm in <xref target="sec-forming"/>. The priority of the local
 candidate depends on its type. Unless the type is peer reflexive, the
@@ -1974,17 +1845,17 @@ candidate information of the peer. If the candidate does not appear
 there, then the check must have been a triggered check to a new remote
 candidate. In that case, the priority is taken as the value of the
 PRIORITY attribute in the Binding request that triggered the check
-that just completed. The pair is then added to the VALID LIST.
+that just completed. The pair is then added to the valid list.
 </t>
 </list></t>
-<t>NOTE: It will be very common that the valid pair will not be in any CHECK LIST.
-Recall that the CHECK LIST has pairs whose local candidates are never
+<t>NOTE: It will be very common that the valid pair will not be in any check list.
+Recall that the check list has pairs whose local candidates are never
 reflexive; those pairs had their local candidates converted to
 the base of the reflexive candidates, and then pruned if they
 were redundant. When the response to the Binding request arrives, the
 mapped address will be reflexive if there is a NAT between the two. In
 that case, the valid pair will have a local candidate that doesn't
-match any of the pairs in the CHECK LIST.
+match any of the pairs in the check list.
 </t>
 </section>
 
@@ -1997,10 +1868,10 @@ valid pair constructed in <xref target="sec-valid-cons"/>.
 </t>
 <t>The success of the connectivity check might also cause the state of other
 candidate pairs to change. The ICE agent MUST set the states for all other
-Frozen candidate pairs (in each CHECK LIST in the CHECK LIST SET) with
+Frozen candidate pairs (in each check list in the check list set) with
 the same foundation to Waiting.
 </t>
-<t>NOTE: Within a given CHECK LIST, candidate pairs with the same foundations will
+<t>NOTE: Within a given check list, candidate pairs with the same foundations will
 typically have different component ID values.
 </t>
 </section>
@@ -2037,12 +1908,12 @@ associated with the candidate pair.
 <section title="Check List State Updates">
 <t>
 Regardless of whether a connectivity check was successful or failed, the
-completion of the check may require updating of CHECK LIST states.
-For each CHECK LIST in the CHECK LIST SET, if all of the candidate pairs
+completion of the check may require updating of check list states.
+For each check list in the check list set, if all of the candidate pairs
 are in either Failed or Succeeded state, and if there is not a valid pair in
-the VALID LIST for each component of the media stream associated with the
-CHECK LIST, the state of the CHECK LIST is set to Failed. If there is a
-valid pair for each component in the VALID LIST, the state of the check
+the valid list for each component of the media stream associated with the
+check list, the state of the check list is set to Failed. If there is a
+valid pair for each component in the valid list, the state of the check
 list is set to Succeeded.
 </t>
 </section>
@@ -2242,11 +2113,11 @@ relay) or a relayed candidate (for cases where it is received through
 a relay).  The local candidate can never be a server reflexive
 candidate. Since both candidates are known to the agent, it can obtain
 their priorities and compute the candidate pair priority. This pair is
-then looked up in the CHECK LIST. There can be one of several
+then looked up in the check list. There can be one of several
 outcomes:
 
 <list style="symbols">
-  <t>If the pair is already on the CHECK LIST:
+  <t>If the pair is already on the check list:
     <list style="symbols">
       <t>If the state of that pair
       is Waiting or Frozen, a check for that pair is enqueued into the
@@ -2282,9 +2153,9 @@ These steps are done to facilitate rapid completion of ICE when both
 agents are behind NAT.
 
 <list style="symbols">
-  <t>If the pair is not already on the CHECK LIST:
+  <t>If the pair is not already on the check list:
   <list style="symbols">
-    <t>The pair is inserted into the CHECK LIST based on its priority.</t>
+    <t>The pair is inserted into the check list based on its priority.</t>
     <t>Its state is set to Waiting.</t>
     <t>The pair is enqueued into the TRIGGERED CHECK QUEUE. </t>
   </list>
@@ -2295,14 +2166,15 @@ agents are behind NAT.
 
 <t>
 When a triggered check is to be sent, it is constructed and processed
-as described in <xref target="sec-send-check"/>. These procedures
-require the agent to know the transport address, username fragment,
-and password for the peer. The username fragment for the remote
-candidate is equal to the part after the colon of the USERNAME in the
-Binding request that was just received. Using that username fragment,
-the agent can check the candidates received from its peer (there
-may be more than one in cases of forking), and find this username
-fragment. The corresponding password is then selected.
+as described in <xref
+target="sec-send-check"/>target="sec-connectivity_check"/>. These
+procedures require the agent to know the transport address, username
+fragment, and password for the peer. The username fragment for the
+remote candidate is equal to the part after the colon of the USERNAME
+in the Binding request that was just received. Using that username
+fragment, the agent can check the candidates received from its peer
+(there may be more than one in cases of forking), and find this
+username fragment. The corresponding password is then selected.
 </t>
 
 <!-- end triggered checks -->
@@ -2344,9 +2216,9 @@ is equal to the transport address on which the request was received,
 and whose remote candidate is equal to the source transport address of
 the request that was received. This candidate pair is assigned an
 arbitrary priority, and placed into a list of valid candidates called
-the VALID LIST. The agent sets the nominated flag for that pair to
+the valid list. The agent sets the nominated flag for that pair to
 true. ICE processing is considered complete for a media stream if the
-VALID LIST contains a candidate pair for each component.
+valid list contains a candidate pair for each component.
 </t>
 
 </section>
@@ -2375,7 +2247,7 @@ updating of state machinery.
 
 <t>Prior to nominating, the agent let connectivity quecks continue until
 some stopping criterion is met. After that, based on an evaluation
-criterion, the agent selects a pair among the valid pairs in the VALID LIST
+criterion, the agent selects a pair among the valid pairs in the valid list
 for nomination.
 </t>
 <t>Once the controlling agent has selected a valid pair for nomination, it
@@ -2385,8 +2257,8 @@ the USE-CANDIDATE attribute. The connectivity check should succeed (since the
 previous did), causing the nominated flag value of that and only that pair
 to be set to true.
 </t>
-<t>Eventually, there will be only a single nominated pair in the VALID LIST for
-each component. Once the state of the CHECK LIST is set to Completed, that exact
+<t>Eventually, there will be only a single nominated pair in the valid list for
+each component. Once the state of the check list is set to Completed, that exact
 pair is selected by ICE for sending and receiving media for that component.
 </t>
 <t>The criterion details for stopping the connectivity checks and for
@@ -2419,26 +2291,26 @@ such controlling agents from using aggressive nomination.
 <t>
 For both controlling and controlled agents, the state of ICE
 processing depends on the presence of nominated candidate pairs in the
-VALID LIST and on the state of the CHECK LIST. Note that, at any time,
+valid list and on the state of the check list. Note that, at any time,
 more than one of the following cases can apply:
 </t>
 
 <t><list style="symbols">
 
-<t>If there are no nominated pairs in the VALID LIST for a media
-stream and the state of the CHECK LIST is Running, ICE processing
+<t>If there are no nominated pairs in the valid list for a media
+stream and the state of the check list is Running, ICE processing
 continues.
 </t>
 
 
-<t>If there is at least one nominated pair in the VALID LIST for a
-media stream and the state of the CHECK LIST is Running:
+<t>If there is at least one nominated pair in the valid list for a
+media stream and the state of the check list is Running:
 <list style="symbols">
 <t>The agent MUST remove all Waiting and Frozen pairs in the CHECK
 LIST and TRIGGERED CHECK QUEUE for the same component as the nominated
 pairs for that media stream.
 </t>
-<t>If an In-Progress pair in the CHECK LIST is for the same component
+<t>If an In-Progress pair in the check list is for the same component
 as a nominated pair, the agent SHOULD cease retransmissions for its
 check if its pair priority is lower than the lowest-priority nominated
 pair for that component.
@@ -2446,42 +2318,42 @@ pair for that component.
 </list>
 </t>
 
-<t>Once there is at least one nominated pair in the VALID LIST for
+<t>Once there is at least one nominated pair in the valid list for
 every component of at least one media stream and the state of the
-CHECK LIST is Running:
+check list is Running:
 <list style="symbols">
-<t>The agent MUST change the state of processing for its CHECK LIST
+<t>The agent MUST change the state of processing for its check list
 for that media stream to Completed. </t>
 <t>The agent MUST continue to respond to any checks it may still
 receive for that media stream, and MUST perform triggered checks if
 required by the processing of <xref target="sec-serverproc"/>.
 </t>
 <t>The agent MUST continue retransmitting any In-Progress checks for
-that CHECK LIST.</t>
+that check list.</t>
 <t>The agent MAY begin transmitting media for this media stream as
 described in <xref target="sec-send-media"/>.
 </t>
 </list>
 </t>
 
-<t>Once the state of each CHECK LIST is Completed:
+<t>Once the state of each check list is Completed:
 <list style="symbols">
 <t>The agent sets the state of ICE processing overall to Completed.</t>
 </list>
 </t>
 
-<t>If the state of the CHECK LIST is Failed, ICE has not been
+<t>If the state of the check list is Failed, ICE has not been
 able to complete for this media stream. The correct behavior depends
-on the state of the CHECK LISTs for other media streams:
+on the state of the check lists for other media streams:
 <list style="symbols">
-<t>If all CHECK LISTs are Failed, ICE processing overall is considered
+<t>If all check lists are Failed, ICE processing overall is considered
 to be in the Failed state, and the agent SHOULD consider the session a
 failure, SHOULD NOT restart ICE, and the controlling agent SHOULD
 terminate the entire session. </t>
-<t>If at least one of the CHECK LISTs for other media streams is
+<t>If at least one of the check lists for other media streams is
 Completed, the controlling agent SHOULD remove the failed media stream
 from the session while sending updated candidate list to its peer.</t>
-<t> If none of the CHECK LISTs for other media streams are
+<t> If none of the check lists for other media streams are
 Completed, but at least one is Running, the agent SHOULD let ICE
 continue.</t>
 </list>
@@ -2541,7 +2413,7 @@ specification), and are from the same IP address family (IPv4 or
 IPv6).
 <list style="symbols">
 <t>If there is a single pair per component, that pair is added to the
-  VALID LIST. If all of the components for a media stream had one
+  valid list. If all of the components for a media stream had one
   pair, the state of ICE processing for that media stream is set to
   Completed. If all media streams are Completed, the state of ICE
   processing is set to Completed overall. This will always be the case
@@ -2753,7 +2625,7 @@ Procedures for sending media differ for full and lite implementations.
 
 <t>
 Agents always send media using a candidate pair, using candidate pairs
-in the VALID LIST. Once a candidate pair has been selected only that
+in the valid list. Once a candidate pair has been selected only that
 candidate pair (referred to as selected pair) is used for
 sending media. An agent will send media to the remote candidate (i.e.,
 setting the destination address and port of the packet equal to that
@@ -2775,14 +2647,14 @@ defined in Section 11 of <xref target="RFC5766"/>.
 The selected pair for a component of a media stream is:
 <list style="symbols">
 <t>
-empty if the state of the CHECK LIST for that media stream is Running,
+empty if the state of the check list for that media stream is Running,
 and there is no previous selected pair for that component due to an
 ICE restart
 </t>
 
 <t>
 equal to the previous selected pair for a component of a media stream
-if the state of the CHECK LIST for that media stream is Running, and
+if the state of the check list for that media stream is Running, and
 there was a previous selected pair for that component due to an ICE
 restart
 </t>
@@ -2803,7 +2675,7 @@ sending media for any component associated with that media stream.
 <section title="Procedures for Lite Implementations">
 
 <t>
-A lite implementation MUST NOT send media until it has a VALID LIST
+A lite implementation MUST NOT send media until it has a valid list
 that contains a candidate pair for each component of that media
 stream. Once that happens, the agent MAY begin sending media
 packets. To do that, it sends media to the remote candidate in the
@@ -3065,7 +2937,7 @@ using the following formula:
   RTO = MAX (500ms, Ta*N * (Num-Waiting + Num-In-Progress))
 
 
-  Num-Waiting: the number of checks in the CHECK LIST in the
+  Num-Waiting: the number of checks in the check list in the
   Waiting state.
 
   Num-In-Progress: the number of checks in the In-Progress state.
@@ -3306,9 +3178,9 @@ this check. Since the check succeeds, agent L creates a new pair,
 whose local candidate is from the mapped address in the Binding
 response (NAT-PUB-1 from message 13) and whose remote candidate is the
 destination of the request (R-PUB-1 from message 10). This is added to
-the VALID LIST. In addition, it is marked as selected since the
+the valid list. In addition, it is marked as selected since the
 Binding request contained the USE-CANDIDATE attribute. Since there is
-a selected candidate pair in the VALID LIST for the one component of this
+a selected candidate pair in the valid list for the one component of this
 media stream, ICE processing for this stream moves into the Completed
 state. Agent L can now send media if it so chooses.
 </t>
@@ -3316,12 +3188,12 @@ state. Agent L can now send media if it so chooses.
 <t>
 Soon after receipt of the STUN Binding request from agent L (message
 11), agent R will generate its triggered check. This check happens to
-match the next one on its CHECK LIST -- from its host candidate to
+match the next one on its check list -- from its host candidate to
 agent L's server reflexive candidate. This check (messages 14-17) will
 succeed. Consequently, agent R constructs a new candidate pair using
 the mapped address from the response as the local candidate (R-PUB-1)
 and the destination of the request (NAT-PUB-1) as the remote
-candidate. This pair is added to the VALID LIST for that media
+candidate. This pair is added to the valid list for that media
 stream. Since the check was generated in the reverse direction of a
 check that contained the USE-CANDIDATE attribute, the candidate pair
 is marked as selected. Consequently, processing for this stream moves

--- a/draft-ietf-ice-rfc5245bis.xml
+++ b/draft-ietf-ice-rfc5245bis.xml
@@ -2216,46 +2216,23 @@ Completed.
 </t>
 
 <t>
-If the peer is a lite agent, 
-Once the candidate exchange has completed, both agents examine their
-candidates and those of its peer. For each media stream, each agent
-pairs up its own candidates with the candidates of its peer for that
-media stream. Two candidates are paired up when they are for the same
-component, utilize the same transport protocol (UDP in this
-specification), and are from the same IP address family (IPv4 or
-IPv6).
-<list style="symbols">
-<t>If there is a single pair per component, that pair is added to the
-  valid list. If all of the components for a media stream had one
-  pair, the state of ICE processing for that media stream is set to
-  Completed. If all media streams are Completed, the state of ICE
-  processing is set to Completed overall. This will always be the case
-  for implementations that are IPv4-only.
+If the peer is a lite agent, the agent pairs local candidates with
+remote candidates that are for the same media stream and have the same
+component, transport protocol, and IP address family.  For each
+component of each media stream, if there is only one canidate pair,
+that pair is added to the valid list.  If there is more than one pair,
+it is RECOMMENDED that an agent follow the procedures of RFC 6724
+<xref target="RFC6724"/> to select a pair and add it to the valid
+list.
 </t>
-<t>
-If there is more than one pair per component:
-<list style="symbols">
-<t>The agent MUST select a pair based on local policy. Since this case
-only arises for IPv6, it is RECOMMENDED that an agent follow the
-procedures of RFC 6724 <xref target="RFC6724"/> to select a single
-pair. </t>
-<t>The agent adds the selected pair for each component to the valid
-list. As described in <xref target="sec-send-media"/>, this will
-permit media to begin flowing. However, it is possible (and in fact
-likely) that both agents have chosen different pairs. </t>
-<t>To reconcile this, the controlling agent MUST send updated
-candidate list which will include the remote-candidates attribute.
-</t>
-<t>The agent MUST NOT update the state of ICE processing until
-after the candidate exchange completes. Then the controlling
-agent MUST change the state of ICE processing to Completed for all
-media streams, and the state of ICE processing overall to
-Completed.
-</t></list></t>
-</list></t>
 
-<!-- peer is lite -->
-</section>
+<t>If all of the components for all media streams had one pair, the
+state of ICE processing is Completed.  Otherwise, the controlling
+agent MUST send an updated candidate list to reconcile different
+agents selecting different candidate pairs.  ICE processing is
+complete after and only after the updated canddiate exchange is
+complete.
+</t>
 
 <!-- procedures for lite -->
 </section>
@@ -2265,23 +2242,12 @@ Completed.
 <section title="Full Implementation Procedures">
 
 <t>
-The procedures in <xref target="sec-conclude"/> require that an
-agent continue to listen for STUN requests and continue to generate
-triggered checks for a media stream, even once processing for that
-stream completes. The rules in this section describe when it is safe
-for an agent to cease sending or receiving checks on a candidate that
-was not selected by ICE, and then free the candidate.
-</t>
-
-<t>
-Once ICE processing has reached the Completed state for all peers for
-media streams using those candidates, the agent SHOULD wait an
-additional three seconds, and then it MAY cease responding to checks or
-generating triggered checks on that candidate.  It MAY free the
-candidate at that time. Freeing of server reflexive candidates is never
-explicit; it happens by lack of a keepalive.  The three-second delay
-handles cases when aggressive nomination is used, and the selected pairs
-can quickly change after ICE has completed.
+A full agent SHOULD NOT stop sending checks and responses from a
+candidate until three seconds after all media streams using that
+candidate are Completed, after which the agent MAY free the candidate
+and stop sending checks and resposnes from it.  The three-second delay
+handles cases when aggressive nomination is used, and the selected
+pairs can quickly change after ICE has completed.
 </t>
 
 </section>
@@ -2289,9 +2255,10 @@ can quickly change after ICE has completed.
 <section title="Lite Implementation Procedures">
 
 <t>
-A lite implementation MAY free candidates not selected by ICE as soon
-as ICE processing has reached the Completed state for all peers for
-all media streams using those candidates.
+A lite agent SHOULD NOT stop sending checks and responses from a
+candidate until after all media streams using that candidate are
+Completed, after which the agent MAY free the candidate and stop
+sending checks and resposnes from it.
 </t>
 
 </section>

--- a/draft-ietf-ice-rfc5245bis.xml
+++ b/draft-ietf-ice-rfc5245bis.xml
@@ -298,8 +298,8 @@ the TURN request will create a binding on each NAT, but only the
 outermost server reflexive candidate (the one nearest the TURN server)
 will be discovered by the agent. If the agent is not behind a NAT,
 then the base candidate will be the same as the server reflexive
-candidate and the server reflexive candidate is redundant and the
-lower priority candidate will be eliminated.
+candidate and the server reflexive candidate is redundant will be
+eliminated.
 </t>
 
 <t>
@@ -398,7 +398,7 @@ send (and receive) messages end-to-end in both directions.
 <section title="Sorting Candidates">
 
 <t>
-Because the algorithm above searches all candidate pairs, if a valid
+Because the algorithm above searches all candidate pairs, if a working
 pair exists it will eventually find it no matter what order the
 candidates are tried in. In order to produce faster (and better)
 results, the candidates are sorted in a specified order. The resulting
@@ -571,7 +571,8 @@ Internet and have a public IP address at which it can receive packets
 from any correspondent. To make it easier for these devices to support
 ICE, ICE defines a special type of implementation called LITE (in
 contrast to the normal FULL implementation). 
-Lite agents do not generate connectivity checks or run
+Lite agents only uses host candidates 
+and does not generate connectivity checks or run
 the state machines, though they need to be able to respond to
 connectivity checks. When a lite implementation connects with a full
 implementation, the full agent takes the role of the controlling
@@ -596,7 +597,7 @@ implementation is preferable if achievable.
 <section title="Usages of ICE">
 
 <t>This document specifies generic use of ICE with protocols that
-provide means to exchange candidate information between the ICE agents.
+provide means to exchange candidate information between the ICE peers.
 The specific details of (i.e how to encode candidate information and
 the actual candidate exchange process) for different protocols using
 ICE are described in separate usage documents. One possible way the
@@ -739,7 +740,7 @@ it to send a check.
 consequence of the receipt of a connectivity check from the peer.
 </t>
 
-<t hangText="Valid list:"> An ordered set of candidate pairs for a
+<t hangText="Valid List:"> An ordered set of candidate pairs for a
 media stream that have been validated by a successful STUN
 transaction.
 </t>
@@ -777,10 +778,8 @@ flag set, it means that it may be selected by ICE for sending and
 receiving media.
 </t>
 
-<t hangText="Selected Pair, Selected Candidate Pair:"> The candidate pair
-selected by an ICE agent for sending media is called the selected
-pair.  Before a pair has been selected, any valid candidate pair
-can be used for sending and receiving media.
+<t hangText="Selected Pair, Selected Candidate Pair:"> The candidate
+pair selected by an ICE agent for sending media.
 </t>
 
 <t hangText="Using Protocol, ICE Usage:"> The protocol that uses ICE
@@ -1221,8 +1220,8 @@ check list.
 <t><list style="hanging">
 <t hangText="Running:">Not yet in the Completed or Failed state.
 </t>
-<t hangText="Completed:">For each component of the media stream, there
-is at least one candidate pair in the Succeeded state.
+<t hangText="Completed:"> The agent has a selected pair for each
+component of the media stream.
 </t>
 <t hangText="Failed:">For any component of the media stream, all
 candidate pairs are in the Failed state.
@@ -1623,7 +1622,7 @@ new attributes.
 <t>The priority attribute MUST be included in a Binding request and be
 set to value computed by the algorithm in <xref
 target="sec-prioritizing"/> for the local candidate, but with a
-candidate type preference for peer-reflexive candidates.
+candidate type preference for peer reflexive candidates.
 </t>
 </section>
 
@@ -1781,13 +1780,13 @@ request and response are symmetric.</t>
 
 <t>The ICE agent MUST check the mapped address from the STUN
 response. If the transport address does not match any of the local
-candidates, the mapped address represents a new peer-reflexive
+candidates, the mapped address represents a new peer reflexive
 candidate which is added to the corresponding check list.
 The type, base, priority, and foundation are computed as follows.
 </t>
 
 <t><list style="symbols">
-<t>The type is peer-reflexive.</t>
+<t>The type is peer reflexive.</t>
 <t>The base is local candidate of the candidate pair
 from which the Binding request was sent.</t>
 <t>The priority is value of the PRIORITY attribute in
@@ -1795,14 +1794,14 @@ the Binding request.</t>
 <t>The foundation is described in <xref target="sec-computing-foundations"/>.</t>
 </list></t>
 
-<t>The ICE agent does not need to pair the peer-reflexive
+<t>The ICE agent does not need to pair the peer reflexive
 candidate with remote candidates, as a valid candiate pair will be
 created due to the procedures in <xref target="sec-valid-cons"/>.
-If an ICE agent wishes to pair the peer-reflexive candidate with
+If an ICE agent wishes to pair the peer reflexive candidate with
 remote candidates other than the one in the valid pair that will
 be generated, the agent MAY provide updated candidate information to
-the peer that includes the peer-reflexive candidate. This will cause
-the peer-reflexive candidate to be paired with all other remote candidates.
+the peer that includes the peer reflexive candidate. This will cause
+the peer reflexive candidate to be paired with all other remote candidates.
 </t>
 </section>
 
@@ -2624,14 +2623,15 @@ Procedures for sending media differ for full and lite implementations.
 <t>
 Agents always send media using a candidate pair, using candidate pairs
 in the valid list. Once a candidate pair has been selected only that
-candidate pair (referred to as selected pair) is used for
-sending media. An agent will send media to the remote candidate (i.e.,
-setting the destination address and port of the packet equal to that
-remote candidate), and will send it from the base associated with the
-candidate pair used for sending media. In case of a relayed
-candidate, media is sent from the agent and forwarded through
-the base (located in the TURN server), using the procedures defined
-in <xref target="RFC5766"/>.
+candidate pair (referred to as selected pair) is used for sending
+media.  Before a pair has been selected, any valid candidate pair can
+be used for sending and receiving media.  An agent will send media to
+the remote candidate (i.e., setting the destination address and port
+of the packet equal to that remote candidate), and will send it from
+the base associated with the candidate pair used for sending media. In
+case of a relayed candidate, media is sent from the agent and
+forwarded through the base (located in the TURN server), using the
+procedures defined in <xref target="RFC5766"/>.
 </t>
 
 <t>


### PR DESCRIPTION
OK, more than a few:

Grammar fixes

Remove RTP/SDP/RTCP/call-specific stuff that's not needed

Remove too much specifics of STUN/TURN that's not needed

Undo some ALL CAPS

Remove duplicate things
- Types of candidates
- The candidate priority algorithm
- How STUN packets are created
- The difference between a full and lite implementation
 - Who can conclude ICE

Remove stuff we don't need to specify
- When an agent gathers candidates
- The sizes and types of information in the candidate encodings
- ICE mismatch
- The using protocol's mechanism for falling back to non-ICE
- 3PCC scenarios
- Details of RTP/RTCP muxing
- Default candidate pairs
- Some low-value NOTEs
- “, and the controlling agent SHOULD terminate the entire session. "
- Justifications for Tr values
- Unknown ICE options forces regular nomination
- Saying what future  specs can and cannot do
- Jitter buffer and marker bit thing

Reword text to make it shorter and more clear
- The role selection
- Forming check lists, candidate pairs,  and states
- Candidate priority algorithm
- Check list pruning
- Removing low-priority candidate pairs
- Order of ICE checks
- Role conflict resolution
- Processing binding request failures and errors
- Check list state updates
- Sending binding responses
- Triggered checks
- Setting the Nomination Flag
- Sending the nomination (especially that it's per-component)
- ICE completion
- Keepalives
- ICE options

Things moved to more logical places
- That we can send media before selecting a candidate pair
- The randomness needed in ufrag and pwd
- Some of the information that needs to be exchanged.
- What the Nominated Flag means
