### PR TITLE
IESG review comments

### DIFF
--- a/draft-ietf-ice-rfc5245bis.xml
+++ b/draft-ietf-ice-rfc5245bis.xml
@@ -3438,10 +3438,11 @@ ICE Agent R:             R_PUB_1       L_PRIV_1      R1
 <t>Messages 18-21: At some point, the controlling agent (agent L) decides 
 to nominate a pair (L2) in the valid list. It performs a connectivity check 
 on the pair (L2), and includes the USE-CANDIDATE attribute in the Binding request. 
-As the check succeeds, the pair (L2) becomes the selected pair of agent L. The
-matching pair (R2) becomes the selected pair of agent R. Consequently, processing 
-for this stream moves into the Completed state. The ICE process also moves into the 
-Completed state.
+As the check succeeds, agent L sets the nominated flag value of the pair (L2) to 'true'. 
+Agent R sets the nominated flag value of the matching pair (R2) to 'true'. As there
+are no more components associated with the stream, the nominated pairs become the 
+selected pairs. Consequently, processing for this stream moves into the Completed state. 
+The ICE process also moves into the Completed state.
 </t>
 </section>
 <section anchor="sec-example-ipv6" title="Example with IPv6 Addresses">
@@ -3629,10 +3630,11 @@ ICE Agent R:             R_PUB_1       L_PUB_1       R1         X
 <t>Messages 11-12: At some point, the controlling agent (agent L) decides 
 to nominate a pair (L1) in the valid list. It performs a connectivity check 
 on the pair (L1), and includes the USE-CANDIDATE attribute in the Binding request. 
-As the check succeeds, the pair (L1) becomes the selected pair of agent L. The
-matching pair (R1) becomes the selected pair of agent R. Consequently, processing 
-for this stream moves into the Completed state. The ICE process also moves into 
-the Completed state.
+As the check succeeds, agent L sets the nominated flag value of the pair (L1) to 'true'. 
+Agent R sets the nominated flag value of the matching pair (R1) to 'true'. As there
+are no more components associated with the stream, the nominated pairs become the 
+selected pairs. Consequently, processing for this stream moves into the Completed state. 
+The ICE process also moves into the Completed state.
 </t>
 </section>
 </section>

--- a/draft-ietf-ice-rfc5245bis.xml
+++ b/draft-ietf-ice-rfc5245bis.xml
@@ -3140,13 +3140,13 @@ based on the following reasoning.
   <list style="numbers">
     <t>Let MaxBytes be the maximum number of bytes allowed to be
     outstanding in the network at start-up, which SHOULD be 14600
-    bytes per RFC 6928.</t>
+    bytes per <xref target="RFC6928"/>.</t>
     <t>Let HTO be the transaction timeout, which SHOULD be 2*RTT if
     RTT is known and 500ms otherwise.  This is based on the RTO for
-    STUN messages from RFC 5389 and the the TCP initial RTO, which is
-    1 sec  in RFC 6298.</t>
+    STUN messages from <xref target="RFC5389"/> and the the TCP initial RTO, which is
+    1 sec in <xref target="RFC6298"/>.</t>
     <t>Let MinPacing be the minimum pacing interval between
-    transactions, which SHOULD be 5ms.</t>
+    transactions, which is 5ms (see above).</t>
   </list>
   </t>
   <t>
@@ -4203,7 +4203,7 @@ a large number of candidates, say, 50. The responding agent receives
 the candidate information, and starts its checks, which are directed
 at the target, and consequently, never generate a response. The
 answerer will start a new connectivity check every Ta ms (say,
-Ta=20ms). However, the retransmission timers are set to a large number
+Ta=50ms). However, the retransmission timers are set to a large number
 due to the large number of candidates. As a consequence, packets will
 be sent at an interval of one every Ta milliseconds, and then with
 increasing intervals after that. Thus, STUN will not send packets at a
@@ -4371,7 +4371,7 @@ Stach, Peter Thatcher, Martin Thomson, Justin Uberti, Suhas
 Nandakumar, Taylor Brandstetter, Peter Saint-Andre, Harald Alvestrand
 and Roman Shpount. Ben Campbill did the AD review. Stephen Farrell did 
 the sec-dir review. Stewart Bryant did the gen-art review. Qin We did 
-the ops-dir review.</t>
+the ops-dir review. Magnus Westerlund did the tsv-art review.</t>
 
 </section>
 
@@ -4412,10 +4412,13 @@ the ops-dir review.</t>
 <?rfc include="reference.RFC.4092"?>
 <?rfc include="reference.RFC.5245"?>
 <?rfc include="reference.RFC.5382"?>
+<?rfc include="reference.RFC.5389"?>
 <?rfc include="reference.RFC.6080"?>
 <?rfc include="reference.RFC.6146"?>
 <?rfc include="reference.RFC.6147"?>
+<?rfc include="reference.RFC.6298"?>
 <?rfc include="reference.RFC.6544"?>
+<?rfc include="reference.RFC.6928"?>
 <?rfc include="reference.RFC.7050"?>
 <?rfc include="reference.RFC.7721"?>
 <?rfc include="reference.RFC.7825"?>

--- a/draft-ietf-ice-rfc5245bis.xml
+++ b/draft-ietf-ice-rfc5245bis.xml
@@ -3161,53 +3161,13 @@ described above. Agents MUST NOT use a RTO value smaller than 500 ms.
 <!-- end Ta and RTO -->
 </section>
 
-<section anchor="sec-example" title="Example">
+<section anchor="sec-example" title="Examples">
+<t>
+This section shows two ICE examples: one using IPv4 addresses, and one using IPv6 addresses.
+</t>
 
 <t>
-The example is based on the simplified topology of <xref
-target="fig-ex-topo"/>.
-</t>
-
-<figure title="Example Topology" anchor="fig-ex-topo"><artwork>
-<![CDATA[
-                         +-------+
-                         |STUN   |
-                         |Server |
-                         +-------+
-                             |
-                  +---------------------+
-                  |                     |
-                  |      Internet       |
-                  |                     |
-                  +---------------------+
-                    |                |
-                    |                |
-             +---------+             |
-             |   NAT   |             |
-             +---------+             |
-                  |                  |
-                  |                  |
-               +-----+            +-----+
-               |  L  |            |  R  |
-               +-----+            +-----+
-]]></artwork></figure>
-
-
-<t> Two ICE agents, L and R, are using ICE. Both are full ICE
-implementations. Both agents have a single IPv4 address. For agent L, it
-is 10.0.1.1 in private address space <xref target="RFC1918"/>, and for
-agent R, 192.0.2.1 on the public Internet. Both are configured with
-the same STUN server (shown in this example for simplicity, although
-in practice the agents do not need to use the same STUN server), which
-is listening for STUN Binding requests at an IP address of 192.0.2.2
-and port 3478. TURN servers are not used in this example. Agent L is
-behind a NAT, and agent R is on the public Internet. The NAT has an
-endpoint independent mapping property and an address dependent
-filtering property. The public side of the NAT has an IP address of
-192.0.2.3.
-</t>
-
-<t> To facilitate understanding, transport addresses are listed using
+To facilitate understanding, transport addresses are listed using
 variables that have mnemonic names. The format of the name is
 entity-type-seqno, where entity refers to the entity whose IP address
 the transport address is on, and is one of "L", "R", "STUN", or
@@ -3217,10 +3177,6 @@ seq-no is a sequence number that is different for each transport
 address of the same type on a particular entity. Each variable has an
 IP address and port, denoted by varname.IP and varname.PORT,
 respectively, where varname is the name of the variable. </t>
-
-<t>The STUN server has advertised transport address STUN-PUB-1 (which
-is 192.0.2.2:3478).
-</t>
 
 <t> In the call flow itself, STUN messages are annotated with several
 attributes. The "S=" attribute indicates the source transport address
@@ -3236,7 +3192,56 @@ and focus on a single data stream between two full
 implementations.
 </t>
 
-<figure title="Example Flow" anchor="fig:basic-ex"><artwork>
+<section anchor="sec-example-ipv4" title="Example with IPv4 Addresses">
+
+<t>
+The example is using the topology shown in <xref target="fig-ex-topo-ipv4"/>.
+</t>
+
+<figure title="Example Topology" anchor="fig-ex-topo-ipv4"><artwork>
+<![CDATA[
+                         +-------+
+                         |STUN   |
+                         |Server |
+                         +-------+
+                             |
+                  +---------------------+
+                  |                     |
+                  |      Internet       |
+                  |                     |
+                  +---------------------+
+                    |                |
+                    |                |
+             +---------+             |
+             |   NAT    |             |
+             +---------+             |
+                  |                  |
+                  |                  |
+               +-----+            +-----+
+               |  L  |            |  R  |
+               +-----+            +-----+
+]]></artwork></figure>
+
+<t> In the example, ICE agents L and R are full ICE implementations. Both 
+agents have a single IPv4 address. Both are configured with the same STUN server.
+The NAT has an endpoint independent mapping property and an address dependent
+filtering property. The IP addresses of the ICE agents, the STUN server and the NAT
+are shown below;
+</t>
+<figure><artwork>
+<![CDATA[
+
+ENTITY                   IP Address  mnemonic name
+--------------------------------------------------
+ICE Agent L:             10.0.1.1    L-PRIV-1
+ICE Agent R:             192.0.2.1   R-PUB-1          
+STUN Server:             192.0.2.2   STUN-PUB-1
+NAT (Public):            192.0.2.3   NAT-PUB-1
+ 
+]]></artwork></figure>
+
+
+<figure title="Example Flow" anchor="fig:basic-ex-ipv6"><artwork>
 <![CDATA[
           L             NAT           STUN             R
           |STUN alloc.   |              |              |
@@ -3343,89 +3348,293 @@ implementations.
           
 ]]></artwork></figure>
 
-<t> First, agent L obtains a host candidate from its local IP address
-(not shown), and from that, sends a STUN Binding request to the STUN
-server to get a server reflexive candidate (messages 1-4). Recall that
-the NAT has the address and port independent mapping property. Here,
-it creates a binding of NAT-PUB-1 for this UDP request, and this
-becomes the server reflexive candidate.  </t>
+<t>Messages 1-4: Agent L gathers a host candidate from its local IP address,
+and from that sends a STUN Binding request to the STUN Server. The request
+creates a NAT binding. The NAT public IP address of the binding becomes
+agent L's server reflexive candidate.</t>
 
-<t>
-Agent L sets a type preference of 126 for the host candidate and 100
-for the server reflexive. The local preference is 65535. Based on
-this, the priority of the host candidate is 2130706431 and for the
-server reflexive candidate is 1694498815. The host candidate is
-assigned a foundation of 1, and the server reflexive, a foundation of
-2. These are sent to the peer.
-</t>
+<t>Message 5: Agent L sends its local candidate information to agent R, using
+the signalling protocol associated with the ICE usage.</t>
 
-<t>
-This candidate information is received at agent R. Agent R will obtain
-a host candidate, and from it, obtain a server reflexive candidate
-(messages 6-7). Since R is not behind a NAT, this candidate is
-identical to its host candidate, and they share the same base. It
-therefore discards this redundant candidate and ends up with a single
-host candidate. With identical type and local preferences as L, the
-priority for this candidate is 2130706431. It chooses a foundation of
-1 for its single candidate. Then R's candidates are then sent to
-L. </t>
+<t>Messages 6-7: Agent R gathers a host candidate from its local IP address,
+and from that sends a STUN Binding request to the STUN Server. Since agent R
+is not behind a NAT, R's server reflexive candidate will be identical to the
+host candidate.
 
-<t>
-Since neither side indicated that it is lite, the initiating agent
-that began ICE processing (agent L) becomes the controlling agent.
-</t>
+<t>Message 8: Agent R sends its local candidate information to agent L, using
+the signalling protocol associated with the ICE usage.</t>
 
-<t>
-Agents L and R both pair up the candidates. They both initially have
+<t>Since both agents are full ICE implementations, the initiating agent (agent L)
+becomes the controlling agent.</t>
+
+<t>Agents L and R both pair up the candidates. Both agents initially have
 two pairs. However, agent L will prune the pair containing its
-server reflexive candidate, resulting in just one. At agent L, this
+server reflexive candidate, resulting in just one (L1). At agent L, this
 pair has a local candidate of $L_PRIV_1 and remote candidate of
-$R_PUB_1, and has a candidate pair priority of 9151314442783293438.
-At agent R, there are two pairs. The highest priority has a local 
-candidate of $R_PUB_1 and remote candidate of $L_PRIV_1 and has a 
-priority of 9151314442783293438, and the second has a local candidate 
-of $R_PUB_1 and remote candidate of $NAT_PUB_1 and priority 
-7277816997797167102.
+$R_PUB_1. At agent R, there are two pairs. The highest priority pair (R1)
+has a local candidate of $R_PUB_1 and remote candidate of $L_PRIV_1, 
+and the second pair (R2) has a local candidate of $R_PUB_1 and remote candidate 
+of $NAT_PUB_1. The pairs are shown below (the pair numbers are for reference purpose 
+only):
 </t>
 
-<t> Agent R begins its connectivity check (message 9) for the first
-pair (between the two host candidates). The host candidate from agent
-L is private and behind a NAT, and thus this check won't be successful,
-because the packet cannot be routed from R to L, and will be dropped
-by the network.
-</t>
+<figure><artwork>
+<![CDATA[
 
-<t> When agent L gets the R's candidates, it performs its one and only
-connectivity check (messages 10-13). Since the check succeeds, agent L
-creates a new pair, whose local candidate is from the mapped address
-in the Binding response (NAT-PUB-1 from message 13) and whose remote
-candidate is the destination of the request (R-PUB-1 from message
-10). This is added to the valid list. Agent L can now send data if it
-so chooses.
+                         Pairs
+ENTITY                   Local         Remote     Pair #     Valid
+------------------------------------------------------------------
+ICE Agent L:             L_PRIV_1      R_PUB_1       L1
+
+ICE Agent R:             R_PUB_1       L_PRIV_1      R1
+                         R_PUB_1       NAT_PUB_1     R2 
+ 
+]]></artwork></figure>
+
+<t>Message 9: Agent R initiates a connectivity check for pair #2.
+As the remote candidate of the pair is the private address of agent L,
+the check will not be successful, as the request cannot be routed
+from R to L, and will be dropped by the network.</t>
+
+<t>Messages 10-13: Agent L initiates a connectivity check for pair L1.
+The check succeeds, and L creates a new pair (L2). The local candidate
+of the new pair is $NAT_PUB_1 and the remote candidate is $R_PUB_1. The
+pair (L2) is added to the valid list of agent L.</t>
+
+<figure><artwork>
+<![CDATA[
+
+                         Pairs
+ENTITY                   Local         Remote     Pair #     Valid
+------------------------------------------------------------------
+ICE Agent L:             L_PRIV_1      R_PUB_1       L1
+                         NAT_PUB_1     R_PUB_1       L2        X
+
+ICE Agent R:             R_PUB_1       L_PRIV_1      R1
+                         R_PUB_1       NAT_PUB_1     R2 
+ 
+]]></artwork></figure>
+
+<t>Messages 14-17: When agent R receives the Binding request from agent L
+(message 11) it will initiate a triggered connectivity check. The pair
+matches one of agent R's existing pairs (R2). The check succeeds, and the
+pair (R2) is added to the valid list of agent R.</t> 
+
+<figure><artwork>
+<![CDATA[
+
+                         Pairs
+ENTITY                   Local         Remote     Pair #     Valid
+------------------------------------------------------------------
+ICE Agent L:             L_PRIV_1      R_PUB_1       L1
+                         NAT_PUB_1     R_PUB_1       L2        X
+
+ICE Agent R:             R_PUB_1       L_PRIV_1      R1
+                         R_PUB_1       NAT_PUB_1     R2        X 
+ 
+]]></artwork></figure>
+.
+
+<t>Messages 18-21: At some point, the controlling agent (agent L) decides 
+to nominate a pair (L2) in the valid list. It performs a connectivity check 
+on the pair (L2), and includes the USE-CANDIDATE attribute in the Binding request. 
+As the check succeeds, the pair (L2) becomes the selected pair of agent L. The
+matching pair (R2) becomes the selected pair of agent R. Consequently, processing 
+for this stream moves into the Completed state. The ICE process also moves into the 
+Completed state.
 </t>
+</section>
+<section anchor="sec-example-ipv6" title="Example with IPv6 Addresses">
 
 <t>
-Soon after receipt of the STUN Binding request from agent L (message
-11), agent R will generate its triggered check. This check happens to
-match the next one on its check list -- from its host candidate to
-agent L's server reflexive candidate. This check (messages 14-17) will
-succeed. Consequently, agent R constructs a new candidate pair using
-the mapped address from the response as the local candidate (R-PUB-1)
-and the destination of the request (NAT-PUB-1) as the remote
-candidate. This pair is added to the valid list for that data
-stream.
-</t>
-<t>
-At some point, the controlling agent (agent L) decides to nominate a
-pair on the valid list. It performs a connectivity check 
-(messages 18-21) using a valid pair, and includes the USE-CANDIDATE 
-attribute. As agent R has previously checked the pair, the check
-from agent L will not trigger a triggered check. As the check
-succeeds, the pair becomes the selected pair. Consequently, processing 
-for this stream moves into the Completed state. As there is only one
-check list, the ICE process also moves into the Completed state.
+The example is using the topology shown in <xref target="fig-ex-topo-ipv6"/>.
 </t>
 
+<figure title="Example Topology" anchor="fig-ex-topo-ipv6"><artwork>
+<![CDATA[
+                         +-------+
+                         |STUN   |
+                         |Server |
+                         +-------+
+                             |
+                  +---------------------+
+                  |                     |
+                  |      Internet       |
+                  |                     |
+                  +---------------------+
+                    |                |
+                    |                |
+                    |                |
+                    |                |
+                    |                |
+                    |                |
+                    |                |
+                 +-----+          +-----+
+                 |  L  |          |  R  |
+                 +-----+          +-----+
+]]></artwork></figure>
+
+<t> In the example, ICE agents L and R are full ICE implementations. Both 
+agents have a single IPv6 address. Both are configured with the same STUN server.
+The IP addresses of the ICE agents and the STUN server are shown below;
+</t>
+<figure><artwork>
+<![CDATA[
+
+ENTITY                   IP Address  mnemonic name
+--------------------------------------------------
+ICE Agent L:             2001:db8::3   L-PUB-1
+ICE Agent R:             2001:db8::5   R-PUB-1          
+STUN Server:             2001:db8::9   STUN-PUB-1
+ 
+]]></artwork></figure>
+
+
+<figure title="Example Flow" anchor="fig:basic-ex-ipv6"><artwork>
+<![CDATA[
+          L                           STUN             R
+          |STUN alloc.                  |              |
+          |(1) STUN Req                 |              |
+          |S=$L-PUB-1                   |              |
+          |D=$STUN-PUB-1                |              |
+          |---------------------------->|              | 
+          |(2) STUN Res                 |              |
+          | S=$STUN-PUB-1               |              |
+          | D=$L-PUB-1                  |              |
+          | MA=$L-PUB-1                 |              |
+          |<----------------------------|              |
+          |(3) L's Candidate Information|              |
+          |------------------------------------------->|
+          |                             |              | STUN
+          |                             |              | alloc.
+          |                             |(4) STUN Req  |
+          |                             |S=$R-PUB-1    |
+          |                             |D=$STUN-PUB-1 |
+          |                             |<-------------|
+          |                             |(5) STUN Res  |
+          |                             |S=$STUN-PUB-1 |
+          |                             |D=$R-PUB-1    |
+          |                             |MA=$R-PUB-1   |
+          |                             |------------->|
+          |(6) R's Candidate Information|              |
+          |<-------------------------------------------|
+          |(7) Bind Req                 |              |
+          |S=$L-PUB-1                   |              |
+          |D=$R-PUB-1                   |              |
+          |------------------------------------------->|
+          |(8) Bind Res                 |              |
+          |S=$R-PUB-1                   |              |
+          |D=$L-PUB-1                   |              |
+          |MA=$L-PUB-1                  |              |
+          |<-------------------------------------------| 
+          |                             |              |
+          |(9) Bind Req                 |              |
+          |S=$R-PUB-1                   |              |
+          |D=$L-PUB-1                   |              |
+          |<-------------------------------------------|
+          |(10) Bind Res                |              |
+          |S=$L-PUB-1                   |              |
+          |D=$R-PUB-1                   |              |
+          |MA=$R-PUB-1                  |              |
+          |------------------------------------------->|
+          |                             |              |
+                             .......                  
+          |                             |              |
+          |(11) Bind Req                |              |
+          |S=$L-PUB-1                   |              |
+          |D=$R-PUB-1                   |              |
+          |USE-CAND                     |              |
+          |------------------------------------------->|
+          |(12) Bind Res                |              |
+          |S=$R-PUB-1                   |              |
+          |D=$L-PUB-1                   |              |
+          |MA=$L-PUB-1                  |              |
+          |<-------------------------------------------| 
+          |              |              |              |
+          
+          
+]]></artwork></figure>
+
+<t>Messages 1-2: Agent L gathers a host candidate from its local IP address,
+and from that sends a STUN Binding request to the STUN Server. Since agent L
+is not behind a NAT, L's server reflexive candidate will be identical to the
+host candidate.</t>
+
+<t>Message 3: Agent L sends its local candidate information to agent R, using
+the signalling protocol associated with the ICE usage.</t>
+
+<t>Messages 4-5: Agent R gathers a host candidate from its local IP address,
+and from that sends a STUN Binding request to the STUN Server. Since agent R
+is not behind a NAT, R's server reflexive candidate will be identical to the
+host candidate.
+
+<t>Message 6: Agent R sends its local candidate information to agent L, using
+the signalling protocol associated with the ICE usage.</t>
+
+<t>Since both agents are full ICE implementations, the initiating agent (agent L)
+becomes the controlling agent.</t>
+
+<t>Agents L and R both pair up the candidates. Both agents initially have
+one pair each. At agent L, the pair (L1) has a local candidate of $L_PUB_1 
+and remote candidate of $R_PUB_1. At agent R, the pair (R1) has a local candidate 
+of $R_PUB_1 and remote candidate of $L_PUB_1. The pairs are shown below 
+(the pair numbers are for reference purpose only):
+</t>
+
+<figure><artwork>
+<![CDATA[
+
+                         Pairs
+ENTITY                   Local         Remote     Pair #     Valid
+------------------------------------------------------------------
+ICE Agent L:             L_PUB_1       R_PUB_1       L1
+
+ICE Agent R:             R_PUB_1       L_PUB_1       R1
+ 
+]]></artwork></figure>
+
+<t>Messages 7-8: Agent L initiates a connectivity check for pair L1.
+The check succeeds, and the pair (L1) is added to the valid list of agent L.</t>
+
+<figure><artwork>
+<![CDATA[
+
+                         Pairs
+ENTITY                   Local         Remote     Pair #     Valid
+------------------------------------------------------------------
+ICE Agent L:             L_PUB_1       R_PUB_1       L1         X
+
+ICE Agent R:             R_PUB_1       L_PUB_1       R1
+ 
+]]></artwork></figure>
+
+<t>Messages 9-10: When agent R receives the Binding request from agent L
+(message 7) it will initiate a triggered connectivity check. The pair
+matches agent R's existing pair (R1). The check succeeds, and the
+pair (R1) is added to the valid list of agent R.</t> 
+
+<figure><artwork>
+<![CDATA[
+
+                         Pairs
+ENTITY                   Local         Remote     Pair #     Valid
+------------------------------------------------------------------
+ICE Agent L:             L_PUB_1       R_PUB_1       L1         X
+
+ICE Agent R:             R_PUB_1       L_PUB_1       R1         X
+ 
+]]></artwork></figure>
+.
+
+<t>Messages 11-12: At some point, the controlling agent (agent L) decides 
+to nominate a pair (L1) in the valid list. It performs a connectivity check 
+on the pair (L1), and includes the USE-CANDIDATE attribute in the Binding request. 
+As the check succeeds, the pair (L1) becomes the selected pair of agent L. The
+matching pair (R1) becomes the selected pair of agent R. Consequently, processing 
+for this stream moves into the Completed state. The ICE process also moves into 
+the Completed state.
+</t>
+</section>
 </section>
 
 <section title="STUN Extensions">

--- a/draft-ietf-ice-rfc5245bis.xml
+++ b/draft-ietf-ice-rfc5245bis.xml
@@ -3244,7 +3244,7 @@ NAT (Public):            192.0.2.3   NAT-PUB-1
 ]]></artwork></figure>
 
 
-<figure title="Example Flow" anchor="fig:basic-ex-ipv6"><artwork>
+<figure title="Example Flow" anchor="fig:basic-ex-ipv4"><artwork>
 <![CDATA[
           L             NAT           STUN             R
           |STUN alloc.   |              |              |
@@ -3304,6 +3304,8 @@ NAT (Public):            192.0.2.3   NAT-PUB-1
           |D=$L-PRIV-1   |              |              |
           |MA=$NAT-PUB-1 |              |              |
           |<-------------|              |              |
+          |Data          |              |              |
+          |===========================================>|
           |              |              |              |
           |              |(14) Bind Req |              |
           |              |S=$R-PUB-1    |              |
@@ -3323,6 +3325,8 @@ NAT (Public):            192.0.2.3   NAT-PUB-1
           |              |D=$R-PUB-1    |              |
           |              |MA=$R-PUB-1   |              |
           |              |---------------------------->|
+          |Data          |              |              |
+          |<===========================================|
           |              |              |              |
                              .......                  
           |              |              |              |
@@ -3402,7 +3406,8 @@ from R to L, and will be dropped by the network.</t>
 <t>Messages 10-13: Agent L initiates a connectivity check for pair L1.
 The check succeeds, and L creates a new pair (L2). The local candidate
 of the new pair is $NAT_PUB_1 and the remote candidate is $R_PUB_1. The
-pair (L2) is added to the valid list of agent L.</t>
+pair (L2) is added to the valid list of agent L. Agent L can now send 
+and receive data on the pair (L2) if it wishes.</t>
 
 <figure><artwork>
 <![CDATA[
@@ -3421,7 +3426,8 @@ ICE Agent R:             R_PUB_1       L_PRIV_1      R1
 <t>Messages 14-17: When agent R receives the Binding request from agent L
 (message 11) it will initiate a triggered connectivity check. The pair
 matches one of agent R's existing pairs (R2). The check succeeds, and the
-pair (R2) is added to the valid list of agent R.</t> 
+pair (R2) is added to the valid list of agent R. Agent R can now send and
+receive data on the pair (R2) if it wishes.</t> 
 
 <figure><artwork>
 <![CDATA[
@@ -3530,7 +3536,9 @@ STUN Server:             2001:db8::9   STUN-PUB-1
           |S=$R-PUB-1                   |              |
           |D=$L-PUB-1                   |              |
           |MA=$L-PUB-1                  |              |
-          |<-------------------------------------------| 
+          |<-------------------------------------------|
+          |Data                         |              |
+          |===========================================>|
           |                             |              |
           |(9) Bind Req                 |              |
           |S=$R-PUB-1                   |              |
@@ -3541,6 +3549,8 @@ STUN Server:             2001:db8::9   STUN-PUB-1
           |D=$R-PUB-1                   |              |
           |MA=$R-PUB-1                  |              |
           |------------------------------------------->|
+          |Data                         |              |
+          |<===========================================|
           |                             |              |
                              .......                  
           |                             |              |
@@ -3598,7 +3608,8 @@ ICE Agent R:             R_PUB_1       L_PUB_1       R1
 ]]></artwork></figure>
 
 <t>Messages 7-8: Agent L initiates a connectivity check for pair L1.
-The check succeeds, and the pair (L1) is added to the valid list of agent L.</t>
+The check succeeds, and the pair (L1) is added to the valid list of agent L.
+Agent L can now send and receive data on the pair (L1) if it wishes.</t>
 
 <figure><artwork>
 <![CDATA[
@@ -3615,7 +3626,8 @@ ICE Agent R:             R_PUB_1       L_PUB_1       R1
 <t>Messages 9-10: When agent R receives the Binding request from agent L
 (message 7) it will initiate a triggered connectivity check. The pair
 matches agent R's existing pair (R1). The check succeeds, and the
-pair (R1) is added to the valid list of agent R.</t> 
+pair (R1) is added to the valid list of agent R. Agent R can now send and
+receive data on the pair (R1) if it wishes.</t> 
 
 <figure><artwork>
 <![CDATA[

--- a/draft-ietf-ice-rfc5245bis.xml
+++ b/draft-ietf-ice-rfc5245bis.xml
@@ -97,8 +97,7 @@ cons that make each one optimal in some network topologies, but a
 poor choice in others. The result is that administrators and
 implementers are making assumptions about the topologies of the
 networks in which their solutions will be deployed. This introduces
-complexity and brittleness into the system. What is needed is a single
-solution that is flexible enough to work well in all situations.  </t>
+complexity and brittleness into the system.</t>
 
 <t> This specification defines Interactive Connectivity Establishment
 (ICE) as a technique for NAT traversal for UDP-based data streams
@@ -142,7 +141,7 @@ one or more paths by which they can establish a data session.
 <xref target="fig-ice-ref-arch"/> shows a typical ICE deployment. The agents are 
 labelled L and R. Both L and R are behind their own respective NATs though they may 
 not be aware of it. The type of NAT and its properties are also unknown. L and R 
-are capable of engaging in an candidate exchange process, whose purpose is to set
+are capable of engaging in a candidate exchange process, whose purpose is to set
 up a data session between L and R. Typically, this exchange will
 occur through a signaling server (e.g., SIP proxy).
 </t>
@@ -217,7 +216,7 @@ derived from physical or logical network interfaces, others
 discoverable via STUN and TURN. 
 </t>
 <t>
-At least one viable candidate has a transport address obtained directly 
+The first category of candidates are those with a transport address obtained directly 
 from a local interface. Such a candidate is called a host candidate. 
 The local interface could be Ethernet or WiFi, or it could be one that 
 is obtained through a tunnel mechanism, such as a Virtual Private Network 
@@ -272,7 +271,7 @@ figure, the notation X:x means IP address X and UDP port x.
 
 ]]></artwork></figure>
 
-<t> When the agent sends the TURN Allocate request from IP address and
+<t> When the agent sends a TURN Allocate request from IP address and
 port X:x, the NAT (assuming there is one) will create a binding
 X1':x1', mapping this server reflexive candidate to the host candidate
 X:x. Outgoing packets sent from the host candidate will be translated
@@ -386,7 +385,7 @@ list of sorted candidate pairs is called the check list.
 <t>
 The agent works through the check list by sending a STUN request for
 the next candidate pair on the list periodically. These are called
-ordinary checks. When a STUN transaction succeeds, one or more
+"ordinary checks". When a STUN transaction succeeds, one or more
 candidate pairs will become so called valid pairs, and will be added
 to a candidate pair list called the valid list.
 </t>
@@ -394,7 +393,7 @@ to a candidate pair list called the valid list.
 <t>
 As an optimization, as soon as R gets L's check message, R schedules
 a connectivity check message to be sent to L on the same candidate
-pair. This is called a triggered check, and accelerates the process
+pair. This is called a "triggered check", and accelerates the process
 of finding valid pairs.
 </t>
 
@@ -743,51 +742,16 @@ protocol. </t>
 <t>
 As part of ICE processing, both the initiating and responding agents
 exchange encoded candidate information as defined by the Usage
-Protocol (ICE Usage). Specifics of the encoding mechanism and the
-semantics of candidate information exchange is out of scope of this
-specification.
+Protocol (ICE Usage). The agents perform candidate gathering, 
+candidate prioritization, redundant candidate elimination, and then
+sends the candidates to the peer agent.
 </t>
-
 <t>
-However at a higher level, the diagram below shows how the ICE agents
-(initiator and responder) exchange their respective candidate(s) information.
-</t>
-
-<figure title="Candidate Gathering and Exchange Sequence"
-anchor="fig:basic-cand-exchange" align="left">
-<artwork>
-<![CDATA[
-          Initiating                      Responding
-            Agent                           Agent
-            (I)                             (R)
-Gather,      |                               |
-prioritize,  |                               |
-eliminate    |                               |
-redundant    |                               |
-candidates,  |                               |
-Encode       |                               |
-candidates   |                               |
-             |   I's Candidate Information   |
-             |------------------------------>|
-             |                               | Gather,
-             |                               | prioritize,
-             |                               | eliminate
-             |                               | redundant
-             |                               | candidates,
-             |                               | Encode
-             |                               | candidates
-             |   R's Candidate Information   |
-             |<------------------------------|
-             |                               |
-]]></artwork></figure>
-<t>
-As shown, the agents involved in the candidate exchange perform (1)
-candidate gathering, (2) candidate prioritization, (3) redundant 
-candidate elimination, and (4) sending of the candidates to the peer.
+Specifics of the encoding mechanism and the semantics of candidate information 
+exchange is out of scope of this specification.
 </t>
 
 <section anchor="sec-full-impl-reqs" title="Full Implementation">
-
 
 <section anchor="sec-gathering" title="Gathering Candidates">
 
@@ -833,7 +797,7 @@ component ID of 1, and RTCP a component ID of 2. In case of RTP/RTCP
 multiplexing, a component ID of 1 is used for both RTP and RTCP.</t>
 
 <t>When candidates are obtained, unless the agent knows for sure that
-RTP/RTCP multiplexing will be used (i.e. the agent knows that the
+RTP/RTCP multiplexing will be used (i.e., the agent knows that the
 other agent also supports, and is willing to use, RTP/RTCP
 multiplexing), or unless the agent only supports RTP/RTCP
 multiplexing, the agent MUST obtain a separate candidate for RTCP. If
@@ -892,8 +856,8 @@ following exceptions:
     <t>If one or more host candidates corresponding to an IPv6 
     address generated using a mechanism that prevents location 
     tracking <xref target="RFC7721"/> are gathered, host candidates 
-    corresponding to IPv6 addresses that do allow location tracking, 
-    that are configured on the same interface, and are part of the 
+    corresponding to IPv6 addresses that do allow location tracking 
+    that are configured on the same interface and are part of the 
     same network prefix MUST NOT be gathered; and host candidates 
     corresponding to IPv6 link-local addresses <xref target="RFC4291"/>
     MUST NOT be gathered.</t>
@@ -945,7 +909,7 @@ long-term credential obtained by the client through some other means.
 
 <t>
 The gathering process is controlled using a timer, Ta.
-Every time Ta expires, the agent can generate another new
+Every time Ta expires the agent can generate another new
 STUN or TURN transaction. This transaction can either be a retry of a
 previous transaction that failed with a recoverable error (such as
 authentication failure), or a transaction for a new host candidate and
@@ -1176,21 +1140,11 @@ different for two candidates allocated from different IP addresses,
 and MUST be the same otherwise. A simple integer that increments for
 each IP address will suffice. In addition, each candidate MUST be
 assigned a unique priority amongst all candidates for the same data
-stream. This priority SHOULD be equal to:
-</t>
-
-<figure><artwork>
-<![CDATA[
-priority = (2^24)*(126) +
-           (2^8)*(IP precedence) +
-           (2^0)*(256 - component ID)
-
-]]></artwork></figure>
-
-<t>
-If a host is v4-only, it SHOULD set the IP precedence to 65535. If a
-host is v6 or dual-stack, the IP precedence SHOULD be the precedence
-value for IP addresses described in RFC 6724 <xref target="RFC6724"/>.
+stream. If the formula in <xref target="sec-rec-form"/> is used to
+calculate the priority, the type preference value SHOULD be set to 126.
+If a host is v4-only, the local preference value SHOULD be set to 65535. If a
+host is v6 or dual-stack, the local preference value SHOULD be set to the 
+precedence value for IP addresses described in RFC 6724 <xref target="RFC6724"/>.
 </t>
 
 <t>
@@ -1330,16 +1284,12 @@ full implementations will form check lists, and begin performing connectivity ch
 <section anchor="sec-role" title="Determining Role">
 
 <t>
-For each session, each ICE agent (Initiating and Responding) takes on a
-role. There are two roles -- controlling and controlled. The
-controlling agent is responsible for the choice of the final candidate
-pairs used for communications. For a full agent, this means nominating
-the candidate pairs that can be used by ICE for each data stream, and
-for updating the peer with the ICE's selection, when needed. The
-controlled agent is told which candidate pairs to use for each data
-stream, and does not require updating the peer to signal this
-information. The sections below describe in detail the actual
-procedures followed by controlling and controlled nodes.
+For each session, each ICE agent (Initiating and Responding) takes on
+a role. There are two roles -- controlling and controlled. The
+controlling agent is responsible for the choice of the final
+candidate pairs used for communications. The sections below
+describe in detail the actual procedures followed by controlling and
+controlled agents.
 </t>
 
 <t>
@@ -1572,9 +1522,7 @@ pairs, and check lists.
 The ICE agent computes a priority for each candidate pair. Let G be the
 priority for the candidate provided by the controlling agent. Let D be
 the priority for the candidate provided by the controlled agent.
-The priority for a pair is computed as follows, where G>D?1:0 
-is an expression whose value is 1 if G is greater than
-D, and 0 otherwise.
+The priority for a pair is computed as follows:
 </t>
 
 <t><list style="empty">
@@ -1849,7 +1797,7 @@ the procedures in <xref target="sec-connectivity_check"/>. After that,
 whenever Ta fires the next check list in the Running state in the check list set
 is picked, and a check is performed for a candidate within that check list.
 After the last check list in the Running state in the check list set has been
-processed, the first check list is picked again. Etc.
+processed, the first check list is picked again, etc.
 </t>
 
 <t>
@@ -1886,9 +1834,9 @@ to perform connectivity checks for, abort these steps.
 </list></t>
 
 <t>Once the agent has picked a candidate pair for which a connectivity check is to
-be performed, the agent performs the check by sending a STUN request from the base associated
-with the local candidate of the pair to the remote candidate of the pair, as described in
-<xref target="sec-send-check"/>.
+be performed, the agent performs the check by triggering a STUN transaction, and sends the 
+Binding request from the base associated with the local candidate of the pair to the remote 
+candidate of the pair, as described in <xref target="sec-send-check"/>.
 </t>
 
 
@@ -1904,11 +1852,6 @@ information obtained from its peer. The local username fragment is
 known directly by the agent for its own candidate.
 </t>
 
-<t>The Initiator performs the ordinary checks on receiving the candidate
-information from the Peer (responder) and having formed the check lists.
-On the other hand the responding agent either performs the triggered or
-ordinary checks as described above.
-</t>
 </section>
 </section>
 <!-- end of full implementation -->
@@ -1927,10 +1870,8 @@ ordinary checks as described above.
  only happen if the peer ICE agent is also a lite implementation), it
  selects a candidate pair based on the ones in the candidate exchange 
  (for IPv4, there is only ever one pair), and then updating the peer 
- with the new candidate information reflecting that selection, when 
- needed (it is never needed for an IPv4-only host). The controlled 
- agent is told which candidate pairs to use for each data stream, and 
- no further candidate updates are needed to signal this information.
+ with the new candidate information reflecting that selection, if 
+ needed (it is never needed for an IPv4-only host).
  </t>
 
 </section>
@@ -2151,7 +2092,7 @@ has a type, base, priority, and foundation. They are computed as follows:
 
 <t><list style="symbols">
 <t>The type is peer reflexive.</t>
-<t>The base is local candidate of the candidate pair
+<t>The base is the local candidate of the candidate pair
 from which the Binding request was sent.</t>
 <t>The priority is the value of the PRIORITY attribute in
 the Binding request.</t>
@@ -2178,10 +2119,8 @@ mapped address of the response, and whose remote candidate equals the
 destination address to which the request was sent. This is called a
 valid pair.
 </t>
-<t>The valid pair may equal the pair that generated the connectivity check, or
-it may equal a different pair in a check list (sometimes in a different check list
-than the one to which the pair that generated the connectivity checks),
-or it may be a pair not currently in any check list.
+<t>The valid pair might equal the pair that generated the connectivity check,
+a different pair in the check list, or a pair currently not in the check list.
 </t>
 <t>The agent maintains a separate list, referred to as the valid list. There is
 a valid list for each check list in the check list set. The valid list will contain 
@@ -2344,12 +2283,6 @@ An agent MUST examine the Binding request for either the
 ICE-CONTROLLING or ICE-CONTROLLED attribute. It MUST follow these
 procedures:
 <list style="symbols">
-<t>
-If neither ICE-CONTROLLING nor ICE-CONTROLLED is present in the
-request, the peer agent may have implemented a previous version of
-this specification. There may be a conflict, but it cannot be
-detected.
-</t>
 
 <t>
 If the agent is in the controlling role, and the ICE-CONTROLLING
@@ -2474,22 +2407,11 @@ outcomes:
 <list style="symbols">
   <t>If the pair is already on the check list:
     <list style="symbols">
-      <t>If the state of that pair
-      is Waiting or Frozen, a check for that pair is enqueued into the
-      triggered check queue if not already present.
+      <t>If the state of that pair is In-Progress or Succeeded, nothing further is
+      done. </t>
+      <t>If the state of that pair is Waiting or Frozen, a check for that pair 
+      is enqueued into the triggered check queue if not already present.
       </t>
-
-      <t>If the state of that pair is In-Progress, the agent cancels
-      the in-progress transaction. Cancellation means that the agent
-      will not retransmit the request, will not treat the lack of
-      response to be a failure, but will wait the duration of the
-      transaction timeout for a response. In addition, the agent MUST
-      create a new connectivity check for that pair (representing a
-      new STUN Binding request transaction) by enqueueing the pair in
-      the triggered check queue. The state of the pair is then changed
-      to Waiting.
-      </t>
-
       <t> If the state of the pair is Failed, it is changed to Waiting
       and the agent MUST create a new connectivity check for that pair
       (representing a new STUN Binding request transaction), by
@@ -2498,8 +2420,6 @@ outcomes:
       check list state, if the current check list state is Failed.
       </t>
 
-      <t>If the state of that pair is Succeeded, nothing further is
-      done. </t>
     </list>
   </t>
 </list>
@@ -2627,7 +2547,7 @@ is used for sending and receiving data for that component of the data stream.
 actions for informing the other agent, and e.g., removing the stream. The exact actions are outside
 the scope of this specification.
 </t>
-<t>The criterion details for stopping the connectivity checks and for
+<t>The criteria for stopping the connectivity checks and for
 selecting a pair for nomination, are outside the scope of this specification.
 They are a matter of local optimization. The only requirement is that the
 agent MUST eventually pick one and only one candidate pair and generate a
@@ -2783,7 +2703,7 @@ additional three seconds, and then it can cease responding to checks or
 generating triggered checks on all local candidates other than
 the ones that became selected candidates.
 Once all ICE sessions have ceased using a given local candidate 
-(a candidate may be used by multiple ICE sessions, e.g. in forking scenarios), 
+(a candidate may be used by multiple ICE sessions, e.g., in forking scenarios), 
 the agent can free that candidate.  The three-second delay
 handles cases when aggressive nomination is used, and the selected pairs
 can quickly change after ICE has completed.
@@ -2860,9 +2780,11 @@ criteria that require the roles to be re-determined are fulfilled.
 <t>
 This section defines a new ICE option, 'ice2'. The ICE option
 indicates that the ICE agent that includes it in a candidate exchange
-is compliant to this specification. For example, the
-agent will not use the aggressive nomination procedure
-defined in RFC 5245.
+is compliant to this specification. For example, the agent will not 
+use the aggressive nomination procedure defined in RFC 5245. In addition,
+it will ensure that an RFC 5245-compliant peer does not use aggressive nomination 
+either, as required by Section 14 of RFC 5245 for peers which receive unknown ICE options.
+
 </t>
 <t>
 An agent compliant to this specification MUST inform the peer
@@ -3062,16 +2984,13 @@ One of the complications in achieving interoperability is that ICE
 relies on a distributed algorithm running on both agents to converge
 on an agreed set of candidate pairs. If the two agents run different
 algorithms, it can be difficult to guarantee convergence on the same
-candidate pairs. The nomination procedure described in <xref
-target="sec-conclude"/> eliminates some of the tight coordination by
-delegating the selection algorithm completely to the controlling
-agent. Consequently, when a controlling agent is communicating with a
-peer that supports options it doesn't know about, the agent MUST run 
-the nomination algorithm described in <xref target="sec-conclude"/>. 
-When this algorithm is used, ICE will converge perfectly even when both 
-agents use different pair prioritization algorithms. One of the keys to 
-such convergence is triggered checks, which ensure that the nominated pair 
-is validated by both agents.
+candidate pairs. The nomination procedure described in
+<xref target="sec-conclude"/> eliminates some of the need for tight 
+coordination by delegating the selection algorithm completely to the 
+controlling agent, and ICE will converge perfectly even when both agents 
+use different pair prioritization algorithms. One of the keys to such 
+convergence is triggered checks, which ensure that the nominated pair is 
+validated by both agents.
 </t>
 
 <t>
@@ -3517,7 +3436,7 @@ check list, the ICE process also moves into the Completed state.
 <section anchor="sec-ice-newatts" title="New Attributes">
 
 <t>
-This specification defines four new STUN attributes: PRIORITY,
+This specification defines four STUN attributes: PRIORITY,
 USE-CANDIDATE, ICE-CONTROLLED, and ICE-CONTROLLING.
 </t>
 
@@ -3616,7 +3535,7 @@ capacity that operators need to take into consideration.
 
 <t>
 First and foremost, ICE makes use of TURN and STUN servers, which
-would typically be located in the data centers. The
+would typically be located in data centers. The
 STUN servers require relatively little bandwidth. For each component
 of each data stream, there will be one or more STUN transactions from
 each client to the STUN server. In a basic voice-only IPv4 VoIP
@@ -3636,12 +3555,7 @@ there is no need for a separate STUN server), in addition to the
 traffic for the actual data. The amount of calls requiring
 TURN for data relay is highly dependent on network topologies, and
 can and will vary over time. In a network with 100% behave-compliant
-NATs, it is exactly zero. At time of writing, large-scale consumer
-deployments were seeing between 5 and 10 percent of calls requiring
-TURN servers. Considering a voice-only deployment using G.711 (so 80
-kbps in each direction), with .2 erlangs during the busy hour, this is
-N*3.2 kbps. For a population of one million users, this is 3.2 Gbps,
-assuming a 10% usage of TURN servers.
+NATs, it is exactly zero.
 </t>
 
 <t>
@@ -3726,7 +3640,7 @@ they know how ICE is performing?
 
 <t>
 ICE has built-in features to help deal with these problems. Signaling
-servers, typically deployed in the data centers
+servers, typically deployed in data centers
 of the network operator, will see the contents of the candidate
 exchanges that convey the ICE parameters. These parameters include the
 type of each candidate (host, server reflexive, or relayed), along
@@ -4303,7 +4217,7 @@ sent.
 <section title="IANA Considerations">
 
 <t>
-The original ICE specification registered four new STUN attributes,
+The original ICE specification registered four STUN attributes,
 and one new STUN error response. The STUN attributes and error
 response are reproduced here. In addition, this specification
 registers a new ICE option.

--- a/draft-ietf-ice-rfc5245bis.xml
+++ b/draft-ietf-ice-rfc5245bis.xml
@@ -2014,8 +2014,8 @@ a role conflict, a failure, or a success, according to the procedures below.
     pair belongs, and set the candidate pair state to Waiting. When the
     triggered connectivity check is later performed, the
     ICE-CONTROLLING/ICE-CONTROLLED attribute of the Binding request will
-    indicate the agent's new role. The agent MAY change
-    the tie-breaker value.
+    indicate the agent's new role. The agent MUST change the tie-breaker 
+    value.
     </t>
     <t>NOTE: A role switch requires an agent to recompute pair priorities
     (<xref target="sec-comp-pair-prio"/>), since the priority values
@@ -3672,8 +3672,9 @@ role. The content of the attribute is a 64-bit unsigned integer in
 network byte order, which contains a random number. The number is used
 for solving role conflicts, when it is referred to as the tie-breaker
 value. An ICE agent MUST use the same number for all Binding requests,
-for all streams, within an ICE session. The agent MAY change
-the number when an ICE restart occurs.
+for all streams, within an ICE session, unless it has received a 487 response,
+in which case it MUST change the number (<xref target="sec-recv-response-conf"/>). 
+The agent MAY change the number when an ICE restart occurs.
 </t>
 
 <t>
@@ -3683,7 +3684,9 @@ role. The content of the attribute is a 64-bit unsigned integer in
 network byte order, which contains a random number. As for the
 ICE-CONTROLLED attribute, the number is used for solving role conflicts. 
 An agent MUST use the same number for all Binding requests, for all streams, 
-within an ICE session. The agent MAY change the number when an ICE restart occurs.
+within an ICE session, unless it has received a 487 response, in which case it 
+MUST change the number (<xref target="sec-recv-response-conf"/>). 
+The agent MAY change the number when an ICE restart occurs.
 </t>
 
 </section>

--- a/draft-ietf-ice-rfc5245bis.xml
+++ b/draft-ietf-ice-rfc5245bis.xml
@@ -3021,13 +3021,10 @@ between the two agents in a session is critical.
 </t>
 
 <t>
-First, ICE provides the ice-options attribute. Each extension or
-change to ICE is associated with a token. When an agent supporting
-such an extension or change triggers candidate exchange, it MUST
-include the token for that extension in this attribute. This allows
-each side to know what the other side is doing. This attribute MUST
-NOT be present if the agent doesn't support any ICE extensions or
-changes.
+First, ICE provides the ICE option concept. Each extension or
+change to ICE is associated with an ICE option. When an agent supports
+such an extension or change, it provides the ICE option to the peer agent
+as part of the candidate exchange.
 </t>
 
 <t>

--- a/draft-ietf-ice-rfc5245bis.xml
+++ b/draft-ietf-ice-rfc5245bis.xml
@@ -1148,7 +1148,7 @@ precedence value for IP addresses described in RFC 6724 <xref target="RFC6724"/>
 Next, an agent chooses a default candidate for each component of each
 data stream. If a host is IPv4-only, there would only be one
 candidate for each component of each data stream, and therefore that
-candidate is the default. If a host is IPv6-only hosts, the default candidate 
+candidate is the default. If a host is IPv6-only, the default candidate 
 would typically be a globally scoped IPv6 address. Dual-stack hosts SHOULD 
 allow configuration of whether IPv4 or IPv6 is used for the default candidate, 
 and the configuration needs to be based on which one its administrator believes 
@@ -1831,7 +1831,7 @@ to perform connectivity checks for, abort these steps.
 </list></t>
 
 <t>Once the agent has picked a candidate pair for which a connectivity check is to
-be performed, the agent starts a check, and sends the Binding request from the base 
+be performed, the agent starts a check and sends the Binding request from the base 
 associated with the local candidate of the pair to the remote candidate of the pair, 
 as described in <xref target="sec-send-check"/>.
 </t>
@@ -1997,7 +1997,7 @@ associates the response with the candidate pair for which the Binding request
 was sent. After that, the response is processed according to the procedures for
 a role conflict, a failure, or a success, according to the procedures below.
 </t>
-<section title="Role Conflict">
+<section anchor="sec-recv-response-conf" title="Role Conflict">
     <t>If the Binding request generates a 487 (Role Conflict) error
     response (<xref target="sec-role-conflict"/>), and if the ICE agent 
     included an ICE-CONTROLLED attribute

--- a/draft-ietf-ice-rfc5245bis.xml
+++ b/draft-ietf-ice-rfc5245bis.xml
@@ -2002,7 +2002,7 @@ response).
 <t>
 If the agent is using Diffserv Codepoint markings <xref target="RFC2475"/> 
 in data packets that it will send, the agent SHOULD apply the same markings to
-Binding responses that it will send.
+Binding requests and responses that it will send.
 </t>
 <t>If multiple DSCP markings are used on the data packets, the
 agent SHOULD choose one of them for use with the connectivity check.

--- a/draft-ietf-ice-rfc5245bis.xml
+++ b/draft-ietf-ice-rfc5245bis.xml
@@ -1181,7 +1181,7 @@ candidate is the default. If a host is IPv6 or dual-stack, the
 selection of default is a matter of local policy. This default SHOULD
 be chosen such that it is the candidate most likely to be used with
 a peer. For IPv6-only hosts, this would typically be a globally scoped
-IPv6 address. For dual-stack hosts, the IPv4 address is RECOMMENDED.
+IPv6 address.
 </t>
 
 <t>
@@ -1472,12 +1472,6 @@ perform such multiplexing, it would include just a single component
 for each candidate -- for the combined RTP/RTCP mux. ICE would end up
 acting as if there was just a single component for this candidate.
 </t>
-
-<t> With IPv6 it is common for a host to have multiple host candidates
-for each interface. To keep the amount of resulting candidate pairs
-reasonable and to avoid candidate pairs that are highly unlikely to
-work, IPv6 link-local addresses <xref target="RFC4291"/> MUST NOT be
-paired with other than link-local addresses. </t>
 
 <t>
 The candidate pairs whose local and remote candidates are both the
@@ -3050,8 +3044,7 @@ regular nomination algorithm. When regular nomination is used, ICE
 will converge perfectly even when both agents use different pair
 prioritization algorithms. One of the keys to such convergence is
 triggered checks, which ensure that the nominated pair is validated by
-both agents. Consequently, any future ICE enhancements MUST preserve
-triggered checks.
+both agents.
 </t>
 
 <t>
@@ -3142,7 +3135,7 @@ based on the following reasoning.
     outstanding in the network at start-up, which SHOULD be 14600
     bytes per <xref target="RFC6928"/>.</t>
     <t>Let HTO be the transaction timeout, which SHOULD be 2*RTT if
-    RTT is known and 500ms otherwise.  This is based on the RTO for
+    RTT is known and 500ms otherwise. This is based on the RTO for
     STUN messages from <xref target="RFC5389"/> and the the TCP initial RTO, which is
     1 sec in <xref target="RFC6298"/>.</t>
     <t>Let MinPacing be the minimum pacing interval between
@@ -3200,9 +3193,10 @@ using the following formula:
 <figure><artwork>
 
 <![CDATA[
-  RTO = MAX (500ms, Ta*N * (Num-Waiting + Num-In-Progress))
+  RTO = MAX (500ms, Ta * N * (Num-Waiting + Num-In-Progress))
 
-
+  N: the total number of connectivity checks to be performed.
+  
   Num-Waiting: the number of checks in the check list set in the
   Waiting state.
 
@@ -3593,6 +3587,13 @@ N*3.2 kbps. For a population of one million users, this is 3.2 Gbps,
 assuming a 10% usage of TURN servers.
 </t>
 
+<t>
+The planning considerations above become more significant in multi-media
+scenarios (e.g., audio and video conferences), and when the numbers of
+participants in a session grow.
+</t>
+
+
 </section>
 
 <section title="Gathering and Connectivity Checks">
@@ -3781,7 +3782,7 @@ can be preferred. As NATs begin to dissipate as IPv6 is introduced, server
 reflexive and relayed candidates (both forms of UNSAF addresses)
 simply never get used, because higher-priority connectivity exists to
 the native host candidates. Therefore, the servers get used less and
-less, and can eventually be remove when their usage goes to zero.
+less, and can eventually be removed when their usage goes to zero.
 </t>
 
 <t>
@@ -4168,12 +4169,6 @@ utilized to provide the client with its relayed candidate.
 </t>
 
 <t>
-However, TURN servers are susceptible to DNS attacks for purposes 
-of turning it into a zombie or rogue server. These attacks can be 
-mitigated by DNS-SEC and through good box and software security on TURN servers.
-</t>
-
-<t>
 Even if an attacker has caused the client to believe in a false
 relayed candidate, the connectivity checks cause such a candidate to
 be used only if they succeed. Thus, an attacker needs to launch a false
@@ -4187,7 +4182,7 @@ attack to coordinate.
 
 <t>
 In addition to attacks where the attacker is a third party trying to
-insert fake candidate information or stun messages, there are attacks
+insert fake candidate information or STUN messages, there are attacks
 possible with ICE when the attacker is an authenticated and valid
 participant in the ICE exchange.
 </t>
@@ -4334,7 +4329,7 @@ ICE Option name:
 <t> The purpose of this updated ICE specification is to:
 <list style="symbols">
 <t>Clarify procedures in RFC 5245.</t>
-<t>Make technical changes, due to discovered flows in RFC 5245 and based
+<t>Make technical changes, due to discovered flaws in RFC 5245 and based
 on feedback from the community that has implemented and
 deployed ICE applications based on RFC 5245.</t>
 <t>Make the procedures signaling protocol independent, by

--- a/draft-ietf-ice-rfc5245bis.xml
+++ b/draft-ietf-ice-rfc5245bis.xml
@@ -741,14 +741,11 @@ protocol. </t>
 
 <t>
 As part of ICE processing, both the initiating and responding agents
-exchange encoded candidate information as defined by the Usage
-Protocol (ICE Usage). The agents perform candidate gathering, 
-candidate prioritization, redundant candidate elimination, and then
-sends the candidates to the peer agent.
-</t>
-<t>
-Specifics of the encoding mechanism and the semantics of candidate information 
-exchange is out of scope of this specification.
+gather candidates, prioritize and eliminate redundant candidates,  
+and exchange candidate information with the peer as defined by the 
+Usage Protocol (ICE Usage). Specifics of the candidate encoding 
+mechanism and the semantics of candidate information exchange is out 
+of scope of this specification.
 </t>
 
 <section anchor="sec-full-impl-reqs" title="Full Implementation">
@@ -1834,9 +1831,9 @@ to perform connectivity checks for, abort these steps.
 </list></t>
 
 <t>Once the agent has picked a candidate pair for which a connectivity check is to
-be performed, the agent performs the check by triggering a STUN transaction, and sends the 
-Binding request from the base associated with the local candidate of the pair to the remote 
-candidate of the pair, as described in <xref target="sec-send-check"/>.
+be performed, the agent starts a check, and sends the Binding request from the base 
+associated with the local candidate of the pair to the remote candidate of the pair, 
+as described in <xref target="sec-send-check"/>.
 </t>
 
 

--- a/draft-ietf-ice-rfc5245bis.xml
+++ b/draft-ietf-ice-rfc5245bis.xml
@@ -2615,7 +2615,6 @@ required by the processing of <xref target="sec-serverproc"/>.
 </t>
 <t>The agent MUST continue retransmitting any In-Progress checks for
 that check list.</t>
-</t>
 </list>
 </t>
 
@@ -3179,7 +3178,8 @@ public, and "PRIV" for transport addresses that are private. Finally,
 seq-no is a sequence number that is different for each transport
 address of the same type on a particular entity. Each variable has an
 IP address and port, denoted by varname.IP and varname.PORT,
-respectively, where varname is the name of the variable. </t>
+respectively, where varname is the name of the variable.
+</t>
 
 <t> In the call flow itself, STUN messages are annotated with several
 attributes. The "S=" attribute indicates the source transport address
@@ -3366,7 +3366,7 @@ the signalling protocol associated with the ICE usage.</t>
 <t>Messages 6-7: Agent R gathers a host candidate from its local IP address,
 and from that sends a STUN Binding request to the STUN Server. Since agent R
 is not behind a NAT, R's server reflexive candidate will be identical to the
-host candidate.
+host candidate.</t>
 
 <t>Message 8: Agent R sends its local candidate information to agent L, using
 the signalling protocol associated with the ICE usage.</t>
@@ -3580,7 +3580,7 @@ the signalling protocol associated with the ICE usage.</t>
 <t>Messages 4-5: Agent R gathers a host candidate from its local IP address,
 and from that sends a STUN Binding request to the STUN Server. Since agent R
 is not behind a NAT, R's server reflexive candidate will be identical to the
-host candidate.
+host candidate.</t>
 
 <t>Message 6: Agent R sends its local candidate information to agent L, using
 the signalling protocol associated with the ICE usage.</t>
@@ -4611,7 +4611,6 @@ the ops-dir review. Magnus Westerlund did the tsv-art review.</t>
 <?rfc include="reference.RFC.4092"?>
 <?rfc include="reference.RFC.5245"?>
 <?rfc include="reference.RFC.5382"?>
-<?rfc include="reference.RFC.5389"?>
 <?rfc include="reference.RFC.6080"?>
 <?rfc include="reference.RFC.6146"?>
 <?rfc include="reference.RFC.6147"?>

--- a/draft-ietf-ice-rfc5245bis.xml
+++ b/draft-ietf-ice-rfc5245bis.xml
@@ -3327,11 +3327,11 @@ implementations.
           |              |              |------------->|
           |(8) R's Candidate Information|              |
           |<-------------------------------------------|
-          |              |(9) Bind Req  |              |Begin
-          |              |S=$R-PUB-1    |              |Connectivity
-          |              |D=L-PRIV-1    |              |Checks
-          |              |<----------------------------|
-          |              |Dropped       |              |
+          |              |         (9) Bind Req        |Begin
+          |              |         S=$R-PUB-1          |Connectivity
+          |              |         D=$L-PRIV-1         |Checks
+          |              |         <-------------------|
+          |              |         Dropped             |
           |(10) Bind Req |              |              |
           |S=$L-PRIV-1   |              |              |
           |D=$R-PUB-1    |              |              |
@@ -3350,7 +3350,7 @@ implementations.
           |D=$L-PRIV-1   |              |              |
           |MA=$NAT-PUB-1 |              |              |
           |<-------------|              |              |
-          |Data flows    |              |              |
+          |              |              |              |
           |              |(14) Bind Req |              |
           |              |S=$R-PUB-1    |              |
           |              |D=$NAT-PUB-1  |              |
@@ -3369,8 +3369,32 @@ implementations.
           |              |D=$R-PUB-1    |              |
           |              |MA=$R-PUB-1   |              |
           |              |---------------------------->|
-          |              |              |              |Data flows
-
+          |              |              |              |
+                             .......                  
+          |              |              |              |
+          |(18) Bind Req |              |              |
+          |S=$L-PRIV-1   |              |              |
+          |D=$R-PUB-1    |              |              |
+          |USE-CAND      |              |              |
+          |------------->|              |              |
+          |              |(19) Bind Req |              |
+          |              |S=$NAT-PUB-1  |              |
+          |              |D=$R-PUB-1    |              |
+          |              |USE-CAND      |              |
+          |              |---------------------------->|
+          |              |(20) Bind Res |              |
+          |              |S=$R-PUB-1    |              |
+          |              |D=$NAT-PUB-1  |              |
+          |              |MA=$NAT-PUB-1 |              |
+          |              |<----------------------------|
+          |(21) Bind Res |              |              |
+          |S=$R-PUB-1    |              |              |
+          |D=$L-PRIV-1   |              |              |
+          |MA=$NAT-PUB-1 |              |              |
+          |<-------------|              |              |
+          |              |              |              |
+          
+          
 ]]></artwork></figure>
 
 <t> First, agent L obtains a host candidate from its local IP address
@@ -3419,11 +3443,10 @@ of $R_PUB_1 and remote candidate of $NAT_PUB_1 and priority
 </t>
 
 <t> Agent R begins its connectivity check (message 9) for the first
-pair (between the two host candidates). Since R is the controlled
-agent for this session, the check omits the USE-CANDIDATE
-attribute. The host candidate from agent L is private and behind a
-NAT, and thus this check won't be successful, because the packet
-cannot be routed from R to L.
+pair (between the two host candidates). The host candidate from agent
+L is private and behind a NAT, and thus this check won't be successful,
+because the packet cannot be routed from R to L, and will be dropped
+by the network.
 </t>
 
 <t> When agent L gets the R's candidates, it performs its one and only
@@ -3444,10 +3467,17 @@ succeed. Consequently, agent R constructs a new candidate pair using
 the mapped address from the response as the local candidate (R-PUB-1)
 and the destination of the request (NAT-PUB-1) as the remote
 candidate. This pair is added to the valid list for that data
-stream. Since the check was generated in the reverse direction of a
-check that contained the USE-CANDIDATE attribute, the candidate pair
-is marked as selected. Consequently, processing for this stream moves
-into the Completed state, and agent R can also send data.
+stream.
+</t>
+<t>
+At some point, the controlling agent (agent L) decides to nominate a
+pair on the valid list. It performs a connectivity check 
+(messages 18-21) using a valid pair, and includes the USE-CANDIDATE 
+attribute. As agent R has previously checked the pair, the check
+from agent L will not trigger a triggered check. As the check
+succeeds, the pair becomes the selected pair. Consequently, processing 
+for this stream moves into the Completed state. As there is only one
+check list, the ICE process also moves into the Completed state.
 </t>
 
 </section>

--- a/draft-ietf-ice-rfc5245bis.xml
+++ b/draft-ietf-ice-rfc5245bis.xml
@@ -74,7 +74,7 @@
 
 <t>Protocols establishing communication sessions between peers typically
 involve exchanging IP addresses and ports for the data sources and
-sinks. However this poses challenges when operated through Network Address
+sinks. However, this poses challenges when operated through Network Address
 Translators (NATs) <xref target="RFC3235"/>. These protocols also seek to
 create a data flow directly between participants, so that there is
 no application layer intermediary between them.  This is done to
@@ -93,9 +93,9 @@ description extensions needed to make them work, such as the Session
 Description Protocol (SDP) <xref target="RFC4566"/> attribute for the
 Real Time Control Protocol (RTCP) <xref
 target="RFC3605"/>. Unfortunately, these techniques all have pros and
-cons which, make each one optimal in some network topologies, but a
+cons that make each one optimal in some network topologies, but a
 poor choice in others. The result is that administrators and
-implementors are making assumptions about the topologies of the
+implementers are making assumptions about the topologies of the
 networks in which their solutions will be deployed. This introduces
 complexity and brittleness into the system. What is needed is a single
 solution that is flexible enough to work well in all situations.  </t>
@@ -106,15 +106,15 @@ solution that is flexible enough to work well in all situations.  </t>
 such as TCP <xref target="RFC6544"/>). ICE works by exchanging a
 multiplicity of IP addresses and ports which are then tested for
 connectivity by peer-to-peer connectivity checks. The IP addresses and
-ports are exchanged exchanged using ICE usage-specific mechanisms (for example, including in a
+ports are exchanged using ICE usage-specific mechanisms (for example, including in a
 offer/answer exchange) and the connectivity checks are performed using
-Session Traversal Utilities for NAT (STUN) specification <xref
-target="RFC5389"/>. ICE also makes use of Traversal Using Relays
+STUN <xref target="RFC5389"/>. ICE also makes use of Traversal Using Relays
 around NAT (TURN) <xref target="RFC5766"/>, an extension to STUN.
 Because ICE exchanges a multiplicity of IP addresses and ports for each media
 stream, it also allows for address selection for multihomed and dual-
-stack hosts. For this reason RFC 5245 <xref target="RFC5245"/> deprecated 
-RFC 4091 <xref target="RFC4091"/> and RFC 4092 <xref target="RFC4092"/>.
+stack hosts. For this reason, RFC 5245 <xref target="RFC5245"/> deprecated 
+the solutions previously defined in RFC 4091 <xref target="RFC4091"/> and 
+RFC 4092 <xref target="RFC4092"/>.
 </t>
 
 <t> <xref target="sec-designmotivations"/> provides background information and 
@@ -148,7 +148,7 @@ occur through a signaling server (e.g., SIP proxy).
 </t>
 
 <t>
-In addition to the agents, a signaling server and NATs, ICE is
+In addition to the agents, a signaling server, and NATs, ICE is
 typically used in concert with STUN or TURN servers in the
 network. Each agent can have its own STUN or TURN server, or they can
 be the same.
@@ -467,7 +467,7 @@ pairs will be used for sending and receiving data associated with that data stre
 <section title="ICE Restart">
 <t>
 Once ICE is concluded, it can be restarted at any time for one or all
-of the data streams by either ICE agent. This is done by sending an updated
+of the data streams by either ICE agent. This is done by sending updated
 candidate information indicating a restart.
 </t>
 </section>
@@ -490,9 +490,9 @@ connectivity checks.
 
 <t>This document specifies generic use of ICE with protocols that
 provide means to exchange candidate information between the ICE agents.
-The specific details of (i.e how to encode candidate information and
+The specific details (i.e., how to encode candidate information and
 the actual candidate exchange process) for different protocols
-using ICE (referred to as using protocol) are described in separate 
+using ICE (referred to as "using protocol") are described in separate 
 usage documents. 
 </t>
 <t>
@@ -541,7 +541,7 @@ An initiating agent is an ICE agent that initiates the ICE candidate exchange
 process. </t>
 
 <t hangText="Responding Peer, Responding Agent, Responder:">
-A receiving agent is an ICE agent that receives
+A responding agent is an ICE agent that receives
 and responds to the candidate exchange process initiated by the
 initiating agent. </t>
 
@@ -578,7 +578,7 @@ A data stream may require multiple components, each of which has to
 work in order for the data stream as a whole to work. For RTP/RTCP data streams,
 unless RTP and RTCP are multiplexed in the same port, there 
 are two components per data stream -- one for RTP, and one for RTCP.
-A component has a candidate pair, which cannot be used by other components</t>
+A component has a candidate pair, which cannot be used by other components.</t>
 
 <t hangText="Host Candidate:"> A candidate obtained by binding to a
 specific port from an IP address on the host. This includes IP
@@ -605,6 +605,15 @@ for a particular candidate. For host, server reflexive and peer reflexive
 candidates the base is the same as the host candidate. For relayed
 candidates the base is the same as the relayed candidate (i.e., 
 the transport address used by the TURN server to send from).
+</t>
+
+<t hangText="Related Address and Port:"> 
+A transport address related to a candidate, useful for diagnostics and other purposes.
+If a candidate is server or peer reflexive, the related address and port is equal to the base
+for that server or peer reflexive candidate. If the candidate is relayed, the related address 
+and port is equal to the mapped address in the Allocate response that provided the client 
+with that relayed candidate. If the candidate is a host candidate, the related address and port 
+is identical to the host candidate.
 </t>
 
 <t hangText="Foundation:"> An arbitrary string used in the freezing
@@ -689,9 +698,13 @@ other is the controlled agent.
 controlling agent to nominate a candidate pair.
 </t>
 
-<t hangText="Nomination, Regular Nomination:"> The process of the
-controlling agent indicating to the controlled agent which candidate
-pair the ICE agents will use for sending and receiving data.
+<t hangText="Nomination:"> The process of the controlling agent
+indicating to the controlled agent which candidate pair the ICE
+agents will use for sending and receiving data. The nomination
+process defined in this specification was referred to "regular nomination"
+in RFC 5245. The nomination process that was referred
+to "aggressive nomination" in RFC 5245 has been deprecated in
+this specification.
 </t>
 
 <t hangText="Nominated, Nominated Flag:"> Once the nomination of a 
@@ -840,8 +853,8 @@ RTCP. However, absence of a component ID 2 as such does not imply use
 of RTCP/RTP multiplexing, as it could also mean that RTCP is not
 used. </t>
 
-<t> For other than RTP/RTCP streams, use of multiple components is
-discouraged since using them increases the complexity of ICE
+<t> For uses other than RTP/RTCP streams, use of multiple components is
+discouraged, since using them increases the complexity of ICE
 processing. If multiple components are needed, the component IDs
 SHOULD start with 1 and increase by 1 for each component.
 </t>
@@ -876,10 +889,15 @@ following exceptions:
     interface, and are part of the same network prefix MUST NOT be
     gathered.</t>
 
-    <t>Host candidates corresponding to IPv6 link-local addresses MUST NOT 
-    be gathered.</t>
+    <t>If one or more host candidates corresponding to an IPv6 
+    address generated using a mechanism that prevents location 
+    tracking <xref target="RFC7721"/> are gathered, host candidates 
+    corresponding to IPv6 addresses that do allow location tracking, 
+    that are configured on the same interface, and are part of the 
+    same network prefix MUST NOT be gathered; and host candidates 
+    corresponding to IPv6 link-local addresses <xref target="RFC4291"/>
+    MUST NOT be gathered.</t>
   </list>
-
 </t>
 
 <t>The IPv6 default address selection specification <xref target="RFC6724"/> 
@@ -981,7 +999,8 @@ server reflexive, or peer reflexive).</t>
 same IP address (the ports can be different).</t>
 
 <t>For reflexive and relayed candidates, the STUN or TURN servers used
-to obtain them have the same IP address.
+to obtain them have the same IP address (the IP address used by the
+agent to contact the STUN or TURN server).
 </t>
 
 <t>They were obtained using the same transport protocol (TCP, UDP).
@@ -991,8 +1010,9 @@ to obtain them have the same IP address.
 
 <t> Similarly, two candidates have different foundations if their
 types are different, their bases have different IP addresses, the STUN
-or TURN servers used to obtain them have different IP addresses, or
-their transport protocols are different.
+or TURN servers used to obtain them have different IP addresses
+(the IP addresses used by the agent to contact the STUN or TURN server), 
+or their transport protocols are different.
 </t>
 
 </section>
@@ -1177,12 +1197,11 @@ value for IP addresses described in RFC 6724 <xref target="RFC6724"/>.
 Next, an agent chooses a default candidate for each component of each
 data stream. If a host is IPv4-only, there would only be one
 candidate for each component of each data stream, and therefore that
-candidate is the default. If a host is IPv6 or dual-stack, the
-selection of default is a matter of local policy. This default SHOULD
-be chosen such that it is the candidate most likely to be used with
-a peer. For IPv6-only hosts, this would typically be a globally scoped
-IPv6 address.
-</t>
+candidate is the default. If a host is IPv6-only hosts, the default candidate 
+would typically be a globally scoped IPv6 address. Dual-stack hosts SHOULD 
+allow configuration of whether IPv4 or IPv6 is used for the default candidate, 
+and the configuration needs to be based on which one its administrator believes 
+has a higher chance of success in the current network environment.</t>
 
 <t>
 The procedures in this section are common across the initiating and
@@ -1261,10 +1280,11 @@ convey this information to its peer. It is a boolean flag.
 
 <t>
 The using protocol may (or may not) need to deal with backwards
-compatibility with older implementations that do not support ICE. If
-the fallback mechanism is being used, then presumably the using
-protocol provides a way of conveying the default candidate (its IP
-address and port) in addition to the ICE parameters.
+compatibility with older implementations that do not support ICE. 
+If a fallback mechanism to non-ICE is supported is being used, 
+then presumably the using protocol provides a way of conveying the 
+default candidate (its IP address and port) in addition to the 
+ICE parameters.
 </t>
 
 <t>
@@ -1280,7 +1300,8 @@ for data.
 <section anchor="sec-verify" title="ICE Mismatch">
 <t>
 Certain middleboxes, such as ALGs, can alter signaling
-information in ways that break ICE. This is referred to as ICE mismatch.
+information in ways that break ICE break ICE (for example, by rewriting 
+IP addresses in SDP). This is referred to as ICE mismatch.
 If the using protocol is vulnerable to ICE mismatch, the responding 
 agent needs to be able to detect it and inform the peer ICE agent 
 about the ICE mismatch. 
@@ -1327,7 +1348,7 @@ follows:
 </t>
 
 <t><list style="hanging">
-<t hangText="Both agents are full:"> The initiating agent which
+<t hangText="Both agents are full:"> The initiating agent that
 started the ICE processing MUST take the controlling role, and the
 other MUST take the controlled role. Both agents will form check
 lists, run the ICE state machines, and generate connectivity
@@ -1353,7 +1374,7 @@ of ICE processing for each data stream is considered to be Running,
 and the state of ICE overall is Running.
 </t>
 
-<t hangText="Both lite:"> The initiating agent which started the ICE
+<t hangText="Both lite:"> The initiating agent that started the ICE
 processing MUST take the controlling role, and the other MUST take the
 controlled role. In this case, no connectivity checks are ever
 sent. Rather, once the candidates are exchanged, each agent performs
@@ -1391,8 +1412,8 @@ re-determined due to the role conflict procedures in <xref target="sec-role-conf
 </t>
 
 <t>
-NOTE: There are certain 3PCC (third party call control) scenarios where an ICE restart might cause
-a role conflict.
+NOTE: There are certain 3PCC (third party call control)  <xref target="RFC3725"/> scenarios 
+where an ICE restart might cause a role conflict.
 </t>
 
 <t>
@@ -1414,10 +1435,10 @@ peer is compliant with RFC 5245.
 
 <t>
 There is one check list for each data stream. To form a check list,
-initiating and responding ICE agents form candidate pairs, computes
-pair priorities, orders pairs by priority, prunes pairs, removes
-lower-priority pairs, and sets check list states. If candidates are
-added to a check list (e.g, due to detection of peer reflexive
+initiating and responding ICE agents form candidate pairs, compute
+pair priorities, order pairs by priority, prune pairs, remove
+lower-priority pairs, and set check list states. If candidates are
+added to a check list (e.g., due to detection of peer reflexive
 candidates), the agent will re-perform these steps for the updated
 check list.
 </t>
@@ -1471,6 +1492,13 @@ candidates for RTP and RTCP on separate ports. If the peer agent can
 perform such multiplexing, it would include just a single component
 for each candidate -- for the combined RTP/RTCP mux. ICE would end up
 acting as if there was just a single component for this candidate.
+</t>
+
+<t>With IPv6 it is common for a host to have multiple host candidates
+for each interface. To keep the amount of resulting candidate pairs
+reasonable and to avoid candidate pairs that are highly unlikely to
+work, IPv6 link-local addresses MUST NOT be paired with other than 
+link-local addresses.
 </t>
 
 <t>
@@ -1725,10 +1753,10 @@ have that foundation is not the first check list in the check list set.
 </t>
 
 <t>
-The table in <xref target="fig-state-initial"/> illustrates an example.
+The table below illustrates an example.
 </t>
 
-<figure title="Initial Pair State" anchor="fig-state-initial" align="center"><artwork>
+<figure anchor="fig-state-initial" align="center"><artwork>
 <![CDATA[
 
 Table legend:
@@ -1857,7 +1885,7 @@ to perform connectivity checks for, abort these steps.
 
 </list></t>
 
-<t>Once the agent has picked a candidate pair, for which a connectivity check is to
+<t>Once the agent has picked a candidate pair for which a connectivity check is to
 be performed, the agent performs the check by sending a STUN request from the base associated
 with the local candidate of the pair to the remote candidate of the pair, as described in
 <xref target="sec-send-check"/>.
@@ -1889,7 +1917,7 @@ ordinary checks as described above.
 <section anchor="sec-candidate_proc_lite" title="Lite Implementation Procedures">
 
  <t>
- Lite implementations skips most of the steps in <xref
+ Lite implementations skip most of the steps in <xref
  target="sec-candidate_proc"/> except for verifying the peer's ICE
  support and determining its role in the ICE processing.
  </t>
@@ -2080,7 +2108,7 @@ a role conflict, a failure, or a success, according to the procedures below.
     <t>
     An ICE agent MAY support processing of ICMP errors for connectivity
     checks. If the agent supports processing of ICMP errors, and if a
-    Binging request generates a hard ICMP error, the agent SHOULD set the
+    Binding request generates a hard ICMP error, the agent SHOULD set the
     state of the candidate pair to Failed. Implementers need to be aware
     that ICMP errors can be used as a method for denial of service attacks
     when making a decision on how and if to process ICMP errors.
@@ -2267,7 +2295,7 @@ message integrity check. Likewise, the short-term credential mechanism
 MUST be used for the response. The agent MUST consider the username to
 be valid if it consists of two values separated by a colon, where the
 first value is equal to the username fragment generated by the agent
-in an candidate exchange for a session in-progress. It is possible
+in a candidate exchange for a session in-progress. It is possible
 (and in fact very likely) that the initiating agent will receive a
 Binding request prior to receiving the candidates from its peer. If
 this happens, the agent MUST immediately generate a response
@@ -2610,10 +2638,16 @@ the controlled agent accepts multiple nominations requests, the agents
 MUST produce the selected pairs using the pairs with the highest priority.</t>
 <t>NOTE: A controlling agent that does not support this specification (i.e. it
 is implemented according to RFC 5245) might nominate more than one candidate pair.
-This was referred to as aggressive nomination in RFC 5245. The usage of the
+This was referred to as "aggressive nomination" in RFC 5245. The usage of the
 'ice2' ice option (<xref target="sec-ice-option"/>) by endpoints supporting this 
 specification is supposed to prevent such controlling agents from using aggressive nomination.
 </t>
+<t>NOTE: In RFC 5245, usage of "aggressive nomination" allowed agents to continuously nominate
+pairs, before a pair was eventually selected, in order to allow sending of data on those pairs.
+In this specification, data can always be sent on any valid pair, without nomination. Hence,
+there is no longer a need for aggressive nomination.
+</t>
+
 
 </section>
 
@@ -2661,8 +2695,6 @@ required by the processing of <xref target="sec-serverproc"/>.
 </t>
 <t>The agent MUST continue retransmitting any In-Progress checks for
 that check list.</t>
-<t>The agent MAY begin transmitting data for this data stream as
-described in <xref target="sec-send-media"/>.
 </t>
 </list>
 </t>
@@ -2785,7 +2817,7 @@ using those candidates.
 <t>
 An ICE agent MAY restart ICE for existing data streams. An ICE restart
 causes all previous state of the data streams, excluding the roles of
-the agents to be flushed.  The only difference between an ICE restart
+the agents, to be flushed.  The only difference between an ICE restart
 and a brand new data session is that during the restart, data can
 continue to be sent using existing data sessions, and that a new data
 session always requires the roles to be determined.
@@ -2806,9 +2838,7 @@ The following actions can be accomplished only using an ICE restart
 
 <t>
 To restart ICE, an agent MUST change both the password and the
-username fragment for the data stream(s) being restarted. The agent
-MUST verify that it has not used the new values in recent ICE sessions,
-as packets from those sessions might still be present in the network. 
+username fragment for the data stream(s) being restarted.  
 </t>
 <t>
 When the ICE is restarted, the candidate set for the new ICE session 
@@ -2914,7 +2944,7 @@ selected pairs have been produced for the data stream.
 
 <t>
 Once selected pairs have been produced for a data stream, an 
-agent MUST send data on those pairs.
+agent MUST send data on those pairs only.
 </t>
 
 <t>
@@ -2982,7 +3012,7 @@ candidate pairs (and, once selected pairs have been produced, only
 on the selected pairs) ICE implementations SHOULD by default be prepared
 to receive data on any of the candidates provided in the most recent
 candidate exchange with the peer. ICE usages MAY define rules
-that differs from this, e.g., by defining that data will not be sent
+that differ from this, e.g., by defining that data will not be sent
 until selected pairs have been produced for a data stream.
 </t>
 
@@ -3032,16 +3062,16 @@ One of the complications in achieving interoperability is that ICE
 relies on a distributed algorithm running on both agents to converge
 on an agreed set of candidate pairs. If the two agents run different
 algorithms, it can be difficult to guarantee convergence on the same
-candidate pairs. The regular nomination procedure described in <xref
+candidate pairs. The nomination procedure described in <xref
 target="sec-conclude"/> eliminates some of the tight coordination by
 delegating the selection algorithm completely to the controlling
 agent. Consequently, when a controlling agent is communicating with a
-peer that supports options it doesn't know about, the agent MUST run a
-regular nomination algorithm. When regular nomination is used, ICE
-will converge perfectly even when both agents use different pair
-prioritization algorithms. One of the keys to such convergence is
-triggered checks, which ensure that the nominated pair is validated by
-both agents.
+peer that supports options it doesn't know about, the agent MUST run 
+the nomination algorithm described in <xref target="sec-conclude"/>. 
+When this algorithm is used, ICE will converge perfectly even when both 
+agents use different pair prioritization algorithms. One of the keys to 
+such convergence is triggered checks, which ensure that the nominated pair 
+is validated by both agents.
 </t>
 
 <t>
@@ -3099,7 +3129,7 @@ pairs.
 <section anchor="sec-ta-ta" title="Ta">
 
 <t>
-ICE agents SHOULD use the default Ta value, 50 ms, but MAY use another
+ICE agents SHOULD use a default Ta value, 50 ms, but MAY use another
 value based on the characteristics of the associated data.
 </t>
 
@@ -3129,8 +3159,8 @@ based on the following reasoning.
   applicable to transport protocols:
   <list style="numbers">
     <t>Let MaxBytes be the maximum number of bytes allowed to be
-    outstanding in the network at start-up, which SHOULD be 14600
-    bytes per <xref target="RFC6928"/>.</t>
+    outstanding in the network at start-up, which SHOULD be 14600,
+    as defined in Section 2 of <xref target="RFC6928"/>.</t>
     <t>Let HTO be the transaction timeout, which SHOULD be 2*RTT if
     RTT is known and 500ms otherwise. This is based on the RTO for
     STUN messages from <xref target="RFC5389"/> and the the TCP initial RTO, which is
@@ -3487,7 +3517,7 @@ check list, the ICE process also moves into the Completed state.
 <section anchor="sec-ice-newatts" title="New Attributes">
 
 <t>
-This specification defines four new STUN attributes, PRIORITY,
+This specification defines four new STUN attributes: PRIORITY,
 USE-CANDIDATE, ICE-CONTROLLED, and ICE-CONTROLLING.
 </t>
 
@@ -3561,7 +3591,7 @@ equipment. Consequently, it is not necessary to replace or reconfigure
 existing firewall and NAT equipment in order to facilitate deployment
 of ICE. Indeed, ICE was developed to be deployed in environments where
 the Voice over IP (VoIP) operator has no control over the IP network
-infrastructure, including firewalls and NAT.
+infrastructure, including firewalls and NATs.
 </t>
 
 <t>
@@ -3606,7 +3636,7 @@ there is no need for a separate STUN server), in addition to the
 traffic for the actual data. The amount of calls requiring
 TURN for data relay is highly dependent on network topologies, and
 can and will vary over time. In a network with 100% behave-compliant
-NAT, it is exactly zero. At time of writing, large-scale consumer
+NATs, it is exactly zero. At time of writing, large-scale consumer
 deployments were seeing between 5 and 10 percent of calls requiring
 TURN servers. Considering a voice-only deployment using G.711 (so 80
 kbps in each direction), with .2 erlangs during the busy hour, this is
@@ -3674,7 +3704,7 @@ keepalives do not have any real impact on capacity planning.
 
 <t>
 Deployments utilizing a mix of ICE and ICE-lite interoperate
-perfectly. They have been explicitly designed to do so.
+with each other. They have been explicitly designed to do so.
 </t>
 
 <t>
@@ -3736,14 +3766,14 @@ standard solutions such as the configuration framework
 <section anchor="sec-iab" title="IAB Considerations">
 
 <t>
-The IAB has studied the problem of "Unilateral Self-Address Fixing",
+The IAB has studied the problem of "Unilateral Self-Address Fixing" (UNSAF),
 which is the general process by which an ICE agent attempts to determine
 its address in another realm on the other side of a NAT through a
 collaborative protocol reflection mechanism <xref target="RFC3424"/>.
 ICE is an example of a protocol that performs this type of
 function. Interestingly, the process for ICE is not unilateral, but
 bilateral, and the difference has a significant impact on the issues
-raised by IAB. Indeed, ICE can be considered a B-SAF (Bilateral
+raised by the IAB. Indeed, ICE can be considered a B-SAF (Bilateral
 Self-Address Fixing) protocol, rather than an UNSAF
 protocol. Regardless, the IAB has mandated that any protocols
 developed for this purpose document a specific set of
@@ -3944,7 +3974,7 @@ better still.
 </section>
 
 <section anchor="sec-security" title="Security Considerations">
-
+<section title="IP Address Privacy">
 <t>
 The process of probing for candidates reveals the source addresses of
 the client and its peer to any on-network listening attacker, and the
@@ -3972,6 +4002,7 @@ the limit the peer might be able to probe the local network.
 There are several types of attacks possible in an ICE system. The
 subsections consider these attacks and their countermeasures.
 </t>
+</section>
 <section title="Attacks on Connectivity Checks">
 
 <t>
@@ -4047,9 +4078,9 @@ validation, unless the connectivity check was sent with DF=0.
 For code 2 or 3, which are originated by the host, the
 address is expected to be any of the remote agents host, reflexive,
 or relay candidates IP addresses. The ICMP message include the IP header and UDP
-header of the message triggering the error. These fields also needs to
-be validated. The IP destination and UDP destination port needs to match
-either the targeted candidate address and port, or the candidates base
+header of the message triggering the error. These fields also need to
+be validated. The IP destination and UDP destination port need to match
+either the targeted candidate address and port, or the candidate's base
 address. The source IP address and port can be any candidate for the
 same base address of the agent sending the connectivity check. Thus any
 attacker having access to the exchange of the candidates will have the necessary
@@ -4293,6 +4324,9 @@ IANA has registered four STUN attributes:
    0x802A ICE-CONTROLLING
 ]]></artwork></figure>
 
+<t>NOTE TO IANA: Please replace the reference to RFC 5245 in the registry
+with a reference to this specification.</t>
+
 </section>
 
 <section title="STUN Error Responses">
@@ -4307,6 +4341,8 @@ IANA has registered following STUN error response code:
        controlled) that is in conflict with the role of the server.
 ]]></artwork></figure>
 
+<t>NOTE TO IANA: Please replace the reference to RFC 5245 in the registry
+with a reference to this specification.</t>
 
 </section>
 
@@ -4338,7 +4374,7 @@ ICE Option name:
   Description:
 
      The ICE option indicates that the ICE agent using the ICE option
-     is compliant and implemented according to RFC XXXX.
+     is implemented according to RFC XXXX.
 
   Reference:
 
@@ -4391,7 +4427,7 @@ revision of the specification we would like to thank Emil Ivov, Paul
 Kyzivat, Pal-Erik Martinsen, Simon Perrault, Eric Rescorla, Thomas
 Stach, Peter Thatcher, Martin Thomson, Justin Uberti, Suhas
 Nandakumar, Taylor Brandstetter, Peter Saint-Andre, Harald Alvestrand
-and Roman Shpount. Ben Campbill did the AD review. Stephen Farrell did 
+and Roman Shpount. Ben Campbell did the AD review. Stephen Farrell did 
 the sec-dir review. Stewart Bryant did the gen-art review. Qin We did 
 the ops-dir review. Magnus Westerlund did the tsv-art review.</t>
 
@@ -4421,6 +4457,7 @@ the ops-dir review. Magnus Westerlund did the tsv-art review.</t>
 <?rfc include="reference.RFC.3424"?>
 <?rfc include="reference.RFC.3550"?>
 <?rfc include="reference.RFC.3711"?>
+<?rfc include="reference.RFC.3725"?>
 <?rfc include="reference.RFC.3879"?>
 <?rfc include="reference.RFC.4038"?>
 <?rfc include="reference.RFC.4291"?>
@@ -4538,7 +4575,7 @@ paced, and why are these formulas used?
 creating bindings on NAT devices between the client and the STUN
 servers. Experience has shown that many NAT devices have upper limits
 on the rate at which they will create new bindings. Experiments have
-shown that once every 5 ms is well supported.
+shown that once every 5 ms is well-supported.
 This is why Ta has a lower bound of 5 ms. Furthermore,
 transmission of these packets on the network makes use of bandwidth
 and needs to be rate limited by the ICE agent. Deployments based on
@@ -4884,7 +4921,8 @@ access networks that use fairly tight packet schedulers for data.
 <t>
 Additionally, using a Binding Indication allows integrity to be
 disabled, allowing for better performance. This is useful for
-large-scale endpoints, such as PSTN gateways and SBCs.
+large-scale endpoints, such as Public Switched Telephone Network (PSTN) 
+gateways and Session Border Controllers (SBCs).
 </t>
 
 </section>

--- a/draft-ietf-ice-rfc5245bis.xml
+++ b/draft-ietf-ice-rfc5245bis.xml
@@ -618,7 +618,7 @@ is identical to the host candidate.
 <t hangText="Foundation:"> An arbitrary string used in the freezing
 algorithm to group similar candidates.  Is the same for two candidates
 that have the same type, base IP address, protocol (UDP, TCP, etc.),
-and STUN or TURN server.  If any of these are different, then the
+and STUN or TURN server. If any of these are different, then the
 foundation will be different.
 </t>
 
@@ -728,12 +728,15 @@ protocol. </t>
 
 <t hangText="Timer Ta:"> The timer for generating new STUN or TURN transactions.</t>
 
-<t hangText="Timer RTO:"> The retransmission timer for a given STUN or TURN transaction.</t>
+<t hangText="Timer RTO (Retransmission Timout):"> The retransmission timer for a given STUN or TURN transaction.</t>
 
-<t hangText="Timer HTO:"> The timeout timer for a given STUN or TURN transaction.</t>
+<t hangText="Timer HTO (Handshake Timeout):"> The timeout timer for a given STUN or TURN transaction.</t>
 
 </list></t>
-
+<t>
+NOTE: When STUN and TURN are used with ICE, timer HTO is used instead of timer Ti <xref target="RFC3264"/> as 
+transaction timeout timer.
+</t>
 </section>
 
 


### PR DESCRIPTION
Important nits; please address:

1) Sec 14.2: RFC 6928, RFC 5389, and RFC 6298 should be actual references and listed in the reference section.

2) Sec 14.2: Maybe you should really not use normative language in the reasoning part of this section?!
    I find especially this SHOULD in the following sentence confusing (as it doesn't give a reference to another RFC that defines this):
   "Let MinPacing be the minimum pacing interval between
          transactions, which SHOULD be 5ms."
   Given that the previous text says:
  "all transactions from all agents [...] MUST NOT be sent more often than once
   every 5ms"
  My recommendation: please use lower cases "shoulds" and "musts" in the reasoning part!

3) Sec 19.4.1: "(say, Ta=20ms)"
Maybe use also a value of 50ms here to avoid confusion.